### PR TITLE
Add OpenMP target implementation of kernels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,22 @@ if (MODEL STREQUAL "OpenMP")
 
   target_link_libraries(Reduced PUBLIC implement_omp)
 
+elseif (MODEL STREQUAL "OpenMP-target")
+  file(GLOB omp_target_bench_src CONFIGURE_DEPENDS omp-target/*.cpp)
+  add_library(implement_omp_target ${omp_target_bench_src})
+
+  # Add OpenMP flags
+  find_package(OpenMP)
+  if(OpenMP_CXX_FOUND)
+    target_link_libraries(implement_omp_target PUBLIC OpenMP::OpenMP_CXX)
+  endif()
+
+  if(OMP_TARGET STREQUAL "Intel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fiopenmp -fopenmp-targets=spir64")
+  endif()
+
+  target_link_libraries(Reduced PUBLIC implement_omp_target)
+
 elseif(MODEL STREQUAL "Kokkos")
   file(GLOB kokkos_bench_src CONFIGURE_DEPENDS kokkos/*.cpp)
   add_library(implement_kokkos ${kokkos_bench_src})

--- a/src/omp-target/complex_min.cpp
+++ b/src/omp-target/complex_min.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <limits>
+
+#include <omp.h>
+
+#include "../complex_min.hpp"
+
+#include "util.hpp"
+
+template <typename T>
+struct complex_min<T>::data {
+  std::complex<T>* C;
+};
+
+template <typename T>
+complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+template <typename T>
+complex_min<T>::~complex_min() = default;
+
+template <typename T>
+void complex_min<T>::setup() {
+
+  pdata->C = new std::complex<T>[N];
+
+  std::complex<T>* C = pdata->C;
+
+#pragma omp target enter data map(alloc:C[0:N])
+
+  #pragma omp parallel for
+  for (long i = 0; i < N; ++i) {
+    T v = std::abs(static_cast<T>(N)/2.0 - static_cast<T>(i));
+    C[i] = std::complex<T>{v, v};
+  }
+
+#pragma omp target update to(C[0:N])
+
+}
+
+template <typename T>
+void complex_min<T>::teardown() {
+#pragma omp target exit data map(delete:pdata->C)
+
+  delete[] pdata->C;
+}
+
+#pragma omp declare target
+template <typename T>
+std::complex<T> minimum(const std::complex<T> a, const std::complex<T> b) {
+  return std::abs(a) < std::abs(b) ? a : b;
+}
+#pragma omp end declare target
+
+template <typename T>
+std::complex<T> complex_min<T>::run() {
+#pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
+
+  std::complex<T>* C = pdata->C;
+
+  auto big = std::numeric_limits<T>::max();
+  std::complex<T> smallest {big, big};
+
+  #pragma omp target teams distribute parallel for reduction(my_complex_min: smallest)
+  for (long i = 0; i < N; ++i) {
+    smallest = minimum(smallest, C[i]);
+  }
+
+  return smallest;
+}
+
+template struct complex_min<double>;
+template struct complex_min<float>;

--- a/src/omp-target/complex_sum.cpp
+++ b/src/omp-target/complex_sum.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <omp.h>
+
+#include "../complex_sum.hpp"
+
+#include "util.hpp"
+
+template <typename T>
+struct complex_sum<T>::data {
+  std::complex<T>* C;
+};
+
+template <typename T>
+complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+template <typename T>
+complex_sum<T>::~complex_sum() = default;
+
+template <typename T>
+void complex_sum<T>::setup() {
+
+  pdata->C = new std::complex<T>[N];
+
+  std::complex<T>* C = pdata->C;
+
+#pragma omp target enter data map(alloc:C[0:N])
+
+  #pragma omp parallel for
+  for (long i = 0; i < N; ++i) {
+    T v = 2.0 * 1024.0 / static_cast<T>(N);
+    C[i] = std::complex<T>{v, v};
+  }
+
+#pragma omp target update to(C[0:N])
+
+}
+
+
+template <typename T>
+void complex_sum<T>::teardown() {
+#pragma omp target exit data map(delete:pdata->C)
+
+  delete[] pdata->C;
+}
+
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
+
+  std::complex<T>* C = pdata->C;
+
+  std::complex<T> sum {0.0, 0.0};
+
+  #pragma omp declare reduction(my_complex_sum : std::complex<T> : omp_out += omp_in)
+
+  #pragma omp target teams distribute parallel for reduction(my_complex_sum:sum)
+  for (long i = 0; i < N; ++i) {
+    sum += C[i];
+  }
+
+  return sum;
+}
+
+template struct complex_sum<double>;
+template struct complex_sum<float>;

--- a/src/omp-target/complex_sum_soa.cpp
+++ b/src/omp-target/complex_sum_soa.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <omp.h>
+
+#include "../complex_sum_soa.hpp"
+
+#include "util.hpp"
+
+template<typename T>
+struct complex_sum_soa<T>::data {
+  T *real;
+  T *imag;
+};
+
+template<typename T>
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+template<typename T>
+complex_sum_soa<T>::~complex_sum_soa() = default;
+
+template<typename T>
+void complex_sum_soa<T>::setup() {
+
+  pdata->real = new T[N];
+  pdata->imag = new T[N];
+
+  T *real = pdata->real;
+  T *imag = pdata->imag;
+
+#pragma omp target enter data map(alloc:real[0:N], imag[0:N])
+
+  #pragma omp parallel for
+  for (long i = 0; i < N; ++i) {
+    T v = 2.0 * 1024.0 / static_cast<T>(N);
+    real[i] = v;
+    imag[i] = v;
+  }
+
+#pragma omp target update to(real[0:N],imag[0:N])
+
+}
+
+template<typename T>
+void complex_sum_soa<T>::teardown() {
+#pragma omp target exit data map(delete:pdata->real, pdata->imag)
+
+  delete[] pdata->real;
+  delete[] pdata->imag;
+}
+
+
+template<typename T>
+std::tuple<T,T> complex_sum_soa<T>::run() {
+
+  T *real = pdata->real;
+  T *imag = pdata->imag;
+
+  T sum_r = 0.0;
+  T sum_i = 0.0;
+
+  #pragma omp target teams distribute parallel for reduction(+: sum_r, sum_i)
+  for (long i = 0; i < N; ++i) {
+    sum_r += real[i];
+    sum_i += imag[i];
+  }
+
+  return {sum_r, sum_i};
+}
+
+template struct complex_sum_soa<double>;
+template struct complex_sum_soa<float>;

--- a/src/omp-target/describe.cpp
+++ b/src/omp-target/describe.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <limits>
+
+#include <omp.h>
+
+#include "../describe.hpp"
+
+#include "util.hpp"
+
+struct describe::data {
+  double *D;
+};
+
+describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+describe::~describe() = default;
+
+void describe::setup() {
+  pdata->D = new double[N];
+
+  double * D = pdata->D;
+
+#pragma omp target enter data map(alloc:D[0:N])
+
+  #pragma omp parallel for
+  for (long i = 0; i < N; ++i) {
+    D[i] = std::abs(static_cast<double>(N)/2.0 - static_cast<double>(i));
+  }
+
+#pragma omp target update to(D[0:N])
+
+}
+
+describe::result describe::run() {
+
+  double *D = pdata->D;
+
+  // Calculate mean using Kahan summation algorithm, improved by Neumaier
+  double mean = 0.0;
+  double lost = 0.0;
+
+  double min = std::numeric_limits<double>::max();
+  double max = std::numeric_limits<double>::min();
+
+  const long count = N;
+
+#pragma omp target teams distribute parallel for reduction(+:mean, lost) reduction(min:min) reduction(max:max)
+  for (long i = 0; i < N; ++i) {
+    // Mean calculation
+    double val = D[i] / static_cast<double>(count);
+    double t = mean + val;
+    if (std::abs(mean) >= val)
+      lost += (mean - t) + val;
+    else
+      lost += (val - t) + mean;
+
+    mean += val;
+
+    min = std::min(min, D[i]);
+    max = std::max(max, D[i]);
+  }
+
+  mean = mean + lost;
+  double std = 0.0;
+
+#pragma omp target teams distribute parallel for reduction(+:std)
+  for (long i = 0; i < N; ++i) {
+    std += ((D[i] - mean) * (D[i] - mean)) / static_cast<double>(count);
+  }
+
+  return {
+    .count = N,
+    .mean = mean,
+    .std = std::sqrt(std),
+    .min = min,
+    .max = max
+  };
+}
+
+void describe::teardown() {
+#pragma omp target exit data map(delete:pdata->D)
+
+  delete[] pdata->D;
+}

--- a/src/omp-target/dot.cpp
+++ b/src/omp-target/dot.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <omp.h>
+
+#include "../dot.hpp"
+#include "util.hpp"
+
+struct dot::data {
+  double *A;
+  double *B;
+};
+
+dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+dot::~dot() = default;
+
+void dot::setup() {
+  pdata->A = new double[N];
+  pdata->B = new double[N];
+
+  double * A = pdata->A;
+  double * B = pdata->B;
+
+#pragma omp target enter data map(alloc:A[0:N],B[0:N])
+
+  #pragma omp parallel for
+  for (long i = 0; i < N; ++i) {
+    A[i] = 1.0 * 1024.0 / static_cast<double>(N);
+    B[i] = 2.0 * 1024.0 / static_cast<double>(N);
+  }
+
+#pragma omp target update to(A[0:N],B[0:N])
+
+}
+
+double dot::run() {
+
+  double *A = pdata->A;
+  double *B = pdata->B;
+
+  double sum = 0.0;
+
+#pragma omp target teams distribute parallel for reduction(+:sum)
+  for (long i = 0; i < N; ++i) {
+    sum += A[i] * B[i];
+  }
+
+  return sum;
+}
+
+void dot::teardown() {
+#pragma omp target exit data map(delete:pdata->A,pdata->B)
+
+  delete[] pdata->A;
+  delete[] pdata->B;
+}

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <omp.h>
+
+#include "../field_summary.hpp"
+
+#include "util.hpp"
+
+struct field_summary::data {
+  double *xvel;
+  double *yvel;
+  double *volume;
+  double *density;
+  double *energy;
+  double *pressure;
+};
+
+field_summary::field_summary() : pdata{std::make_unique<data>()} {
+
+  if(!is_offloading()) {
+    std::cerr << "OMP target code is not offloading as expecting" << std::endl;
+    exit(1);
+  }
+}
+
+field_summary::~field_summary() = default;
+
+void field_summary::setup() {
+  // Allocate arrays
+  pdata->xvel = new double[(nx+1) * (ny+1)];
+  pdata->yvel = new double[(nx+1) * (ny+1)];
+  pdata->volume = new double[nx * ny];
+  pdata->density = new double[nx * ny];
+  pdata->energy = new double[nx * ny];
+  pdata->pressure = new double[nx * ny];
+
+  const size_t DOF = nx*ny;
+  const size_t DOF_pad = (nx+1)*(ny+1);
+
+  double *xvel = pdata->xvel;
+  double *yvel = pdata->yvel;
+  double *volume = pdata->volume;
+  double *density = pdata->density;
+  double *energy = pdata->energy;
+  double *pressure = pdata->pressure;
+
+#pragma omp target enter data map(alloc:xvel[0:DOF_pad], yvel[0:DOF_pad], \
+  volume[0:DOF], density[0:DOF], energy[0:DOF], pressure[0:DOF])
+
+  // Initalise arrays
+  const double dx = 10.0/static_cast<double>(nx);
+  const double dy = 10.0/static_cast<double>(ny);
+
+  #pragma omp parallel for
+  for (long k = 0; k < ny; ++k) {
+    #pragma omp simd
+    for (long j = 0; j < nx; ++j) {
+
+      volume[j + k*nx] = dx * dy;
+      density[j + k*nx] = 0.2;
+      energy[j + k*nx] = 1.0;
+      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+    }
+  }
+
+  #pragma omp parallel for
+  for (long k = 0; k < ny/5; ++k) {
+    #pragma omp simd
+    for (long j = 0; j < nx/2; ++j) {
+
+      density[j + k*nx] = 1.0;
+      energy[j + k*nx] = 2.5;
+      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+    }
+  }
+
+  #pragma omp parallel for
+  for (long k = 0; k < ny+1; ++k) {
+    #pragma omp simd
+    for (long j = 0; j < nx+1; ++j) {
+      xvel[j + k*(nx+1)] = 0.0;
+      yvel[j + k*(nx+1)] = 0.0;
+    }
+  }
+
+#pragma omp target update to(xvel[0:DOF_pad], yvel[0:DOF_pad], \
+       volume[0:DOF], density[0:DOF], energy[0:DOF], pressure[0:DOF])
+
+}
+
+void field_summary::teardown() {
+#pragma omp target exit data map(delete:pdata->xvel, pdata->yvel, \
+  pdata->volume, pdata->density, pdata->energy, pdata->pressure)
+
+  delete[] pdata->xvel;
+  delete[] pdata->yvel;
+  delete[] pdata->volume;
+  delete[] pdata->density;
+  delete[] pdata->energy;
+  delete[] pdata->pressure;
+}
+
+field_summary::reduction_vars field_summary::run() {
+
+  double *xvel = pdata->xvel;
+  double *yvel = pdata->yvel;
+  double *volume = pdata->volume;
+  double *density = pdata->density;
+  double *energy = pdata->energy;
+  double *pressure = pdata->pressure;
+
+  // Reduction variables
+  double vol = 0.0;
+  double mass = 0.0;
+  double ie = 0.0;
+  double ke = 0.0;
+  double press = 0.0;
+
+  #pragma omp target teams distribute parallel for reduction(+:vol, mass, ie, ke, press)
+  for (long k = 0; k < ny; ++k) {
+    #pragma omp simd reduction(+:vol, mass, ie, ke, press)
+    for (long j = 0; j < nx; ++j) {
+      double vsqrd = 0.0;
+      for (long kv = k; kv <= k+1; ++kv) {
+        for (long jv = j; jv <= j+1; ++jv) {
+          vsqrd += 0.25 * (xvel[jv + kv*(nx+1)] * xvel[jv + kv*(nx+1)] + yvel[jv + kv*(nx+1)] * yvel[jv + kv*(nx+1)]);
+        }
+      }
+      double cell_volume = volume[j + k*nx];
+      double cell_mass = cell_volume * density[j + k*nx];
+      vol += cell_volume;
+      mass += cell_mass;
+      ie += cell_mass * energy[j + k*nx];
+      ke += cell_mass * 0.5 * vsqrd;
+      press += cell_volume * pressure[j + k*nx];
+    }
+  }
+
+  return {vol, mass, ie, ke, press};
+}

--- a/src/omp-target/util.hpp
+++ b/src/omp-target/util.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#pragma <omp.h>
+
+inline bool is_offloading()
+{
+    int dev;
+#pragma omp target map(from:dev)
+    {
+        dev = omp_get_device_num();
+    }
+    return dev != omp_get_initial_device();
+}


### PR DESCRIPTION
This adds OpenMP target implementations of the kernels in the suite. This is based off of the small fix in #1.