### PR TITLE
Format with clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a collection of key reduction kernel patterns collated from other benchm
 ## TODO ##
 
 - [ ] oneDPL
+- [ ] RAJA custom reducer for complex min
 
 
 ## Benchmarks ##

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,5 @@
+
+ColumnLimit: 120
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 # set the project name
 project(Reduced
-  VERSION 0.1
+  VERSION 0.5
   LANGUAGES CXX
 )
 

--- a/src/complex_min.hpp
+++ b/src/complex_min.hpp
@@ -1,14 +1,14 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
-#include <memory>
 #include <complex>
+#include <memory>
 
-template <typename T>
-struct complex_min {
+template <typename T> struct complex_min {
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   const long N;
 
   struct data;
@@ -40,7 +40,4 @@ struct complex_min {
     else // even case
       return std::complex<T>{0.0, 0.0};
   }
-
 };
-
-

--- a/src/complex_min.hpp
+++ b/src/complex_min.hpp
@@ -4,7 +4,8 @@
 #include <complex>
 #include <memory>
 
-template <typename T> struct complex_min {
+template <typename T>
+struct complex_min {
 
   // Problem size and data arrays
   // Data arrays use C++ PIMPL because different models store data with very

--- a/src/complex_sum.hpp
+++ b/src/complex_sum.hpp
@@ -1,14 +1,14 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
-#include <memory>
 #include <complex>
+#include <memory>
 
-template <typename T>
-struct complex_sum {
+template <typename T> struct complex_sum {
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   const long N;
   struct data;
   std::unique_ptr<data> pdata;
@@ -36,7 +36,4 @@ struct complex_sum {
     T v = 2.0 * 1024.0;
     return std::complex<T>{v, v};
   }
-
 };
-
-

--- a/src/complex_sum.hpp
+++ b/src/complex_sum.hpp
@@ -4,7 +4,8 @@
 #include <complex>
 #include <memory>
 
-template <typename T> struct complex_sum {
+template <typename T>
+struct complex_sum {
 
   // Problem size and data arrays
   // Data arrays use C++ PIMPL because different models store data with very

--- a/src/complex_sum_soa.hpp
+++ b/src/complex_sum_soa.hpp
@@ -4,7 +4,8 @@
 #include <memory>
 #include <tuple>
 
-template <typename T> struct complex_sum_soa {
+template <typename T>
+struct complex_sum_soa {
 
   // Problem size and data arrays
   // Data arrays use C++ PIMPL because different models store data with very

--- a/src/complex_sum_soa.hpp
+++ b/src/complex_sum_soa.hpp
@@ -4,11 +4,11 @@
 #include <memory>
 #include <tuple>
 
-template <typename T>
-struct complex_sum_soa {
+template <typename T> struct complex_sum_soa {
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   const long N;
   struct data;
   std::unique_ptr<data> pdata;
@@ -36,7 +36,4 @@ struct complex_sum_soa {
     T v = 2.0 * 1024.0;
     return {v, v};
   }
-
 };
-
-

--- a/src/describe.hpp
+++ b/src/describe.hpp
@@ -1,11 +1,10 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
-#include <memory>
 #include <cmath>
+#include <memory>
 
 struct describe {
-
 
   // Reduction result
   // count: number of items in series
@@ -22,7 +21,8 @@ struct describe {
   };
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   const long N;
   struct data;
   std::unique_ptr<data> pdata;
@@ -57,7 +57,9 @@ struct describe {
     // Even case
     //   Total is sum of integers to N/2 + sum of integers to N/2-1
     //   Equiv, twice the sum of integers N/2-1, plus N/2
-    //   Total = (n/2 - 1) * (n/2) + (n/2) = (n/2) ((n/2) - 1 + 1) = (n/2) * (n/2)
+    //   Total = (n/2 - 1) * (n/2) + (n/2)
+    //         = (n/2) ((n/2) - 1 + 1)
+    //         = (n/2) * (n/2)
     //   mean = (n/2) * (n/2) / n = n/4
     //
     // Odd case
@@ -70,18 +72,19 @@ struct describe {
 
     if (N % 2 == 0) { // even case
       r.mean = static_cast<double>(N) / 4.0;
-    }
-    else { // odd case
+    } else { // odd case
       const double fl_half_n = std::floor(static_cast<double>(N) / 2.0);
       const double half_n = static_cast<double>(N) / 2.0;
-      r.mean = (((fl_half_n-1.0) * fl_half_n) + fl_half_n + half_n) / static_cast<double>(N);
+      r.mean = (((fl_half_n - 1.0) * fl_half_n) + fl_half_n + half_n) /
+               static_cast<double>(N);
     }
 
     // Standard deviation
     // Not sure there is a closed form for the input data.
     r.std = 0;
     for (long i = 0; i < N; ++i) {
-      double val = std::abs(static_cast<double>(N)/2.0 - static_cast<double>(i));
+      double val =
+          std::abs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
       r.std += ((val - r.mean) * (val - r.mean)) / static_cast<double>(N);
     }
     r.std = std::sqrt(r.std);
@@ -94,10 +97,7 @@ struct describe {
 
     // Maximum
     r.max = static_cast<double>(N) / 2.0;
-    
 
     return r;
   }
 };
-
-

--- a/src/describe.hpp
+++ b/src/describe.hpp
@@ -75,16 +75,14 @@ struct describe {
     } else { // odd case
       const double fl_half_n = std::floor(static_cast<double>(N) / 2.0);
       const double half_n = static_cast<double>(N) / 2.0;
-      r.mean = (((fl_half_n - 1.0) * fl_half_n) + fl_half_n + half_n) /
-               static_cast<double>(N);
+      r.mean = (((fl_half_n - 1.0) * fl_half_n) + fl_half_n + half_n) / static_cast<double>(N);
     }
 
     // Standard deviation
     // Not sure there is a closed form for the input data.
     r.std = 0;
     for (long i = 0; i < N; ++i) {
-      double val =
-          std::abs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
+      double val = std::abs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
       r.std += ((val - r.mean) * (val - r.mean)) / static_cast<double>(N);
     }
     r.std = std::sqrt(r.std);

--- a/src/dot.hpp
+++ b/src/dot.hpp
@@ -6,7 +6,8 @@
 struct dot {
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   const long N;
   struct data;
   std::unique_ptr<data> pdata;
@@ -35,6 +36,4 @@ struct dot {
     double b = 2.0 * 1024.0 / static_cast<double>(N);
     return a * b * static_cast<double>(N);
   }
-
 };
-

--- a/src/field_summary.hpp
+++ b/src/field_summary.hpp
@@ -43,8 +43,5 @@ struct field_summary {
   }
 
   // Return theoretical minimum number of GiB moved in run()
-  double gibibytes() {
-    return 1.0E-9 * sizeof(double) *
-           ((4.0 * nx * ny) + (2.0 * (nx + 1) * (ny + 1)));
-  }
+  double gibibytes() { return 1.0E-9 * sizeof(double) * ((4.0 * nx * ny) + (2.0 * (nx + 1) * (ny + 1))); }
 };

--- a/src/field_summary.hpp
+++ b/src/field_summary.hpp
@@ -10,7 +10,8 @@ struct field_summary {
   };
 
   // Problem size and data arrays
-  // Data arrays use C++ PIMPL because different models store data with very different types
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
   long nx = 3840;
   long ny = 3840;
   struct data;
@@ -36,13 +37,8 @@ struct field_summary {
   // Return expected result
   reduction_vars expect() {
     return {
-      0.1000E+03,
-      0.2800E+02,
-      0.4300E+02,
-      0.0000E+00,
-      0.1720E+00*0.1000E+03 // The original code outputs press/vol
+        0.1000E+03, 0.2800E+02, 0.4300E+02, 0.0000E+00,
+        0.1720E+00 * 0.1000E+03 // The original code outputs press/vol
     };
   }
-
 };
-

--- a/src/format.sh
+++ b/src/format.sh
@@ -2,6 +2,3 @@
 
 clang-format -i *.hpp *.cpp kokkos/*.cpp omp/*.cpp omp-target/*.cpp omp-target/*.hpp raja/*.cpp sycl/*.cpp sycl/*.hpp
 
-for f in raja/*.cpp; do
-  sed -i .cpp 's/*RAJA_RESTRICT/* RAJA_RESTRICT/' $f
-done

--- a/src/format.sh
+++ b/src/format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+clang-format -i *.hpp *.cpp kokkos/*.cpp omp/*.cpp omp-target/*.cpp omp-target/*.hpp raja/*.cpp sycl/*.cpp sycl/*.hpp
+

--- a/src/format.sh
+++ b/src/format.sh
@@ -2,3 +2,6 @@
 
 clang-format -i *.hpp *.cpp kokkos/*.cpp omp/*.cpp omp-target/*.cpp omp-target/*.hpp raja/*.cpp sycl/*.cpp sycl/*.hpp
 
+for f in raja/*.cpp; do
+  sed -i .cpp 's/*RAJA_RESTRICT/* RAJA_RESTRICT/' $f
+done

--- a/src/kokkos/complex_min.cpp
+++ b/src/kokkos/complex_min.cpp
@@ -8,9 +8,8 @@
 
 #include "../complex_min.hpp"
 
-template <typename T>
-struct complex_min<T>::data {
-  Kokkos::View<Kokkos::complex<T>*> C;
+template <typename T> struct complex_min<T>::data {
+  Kokkos::View<Kokkos::complex<T> *> C;
 };
 
 template <typename T>
@@ -19,67 +18,53 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Complex Min is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T>
-complex_min<T>::~complex_min() {
-  Kokkos::finalize();
-}
+template <typename T> complex_min<T>::~complex_min() { Kokkos::finalize(); }
 
-template <typename T>
-void complex_min<T>::setup() {
+template <typename T> void complex_min<T>::setup() {
 
-  pdata->C = Kokkos::View<Kokkos::complex<T>*>("C", N);
+  pdata->C = Kokkos::View<Kokkos::complex<T> *>("C", N);
 
   auto C = pdata->C;
 
-  Kokkos::parallel_for(N, KOKKOS_LAMBDA (const int i) {
-    T v = fabs(static_cast<T>(N)/2.0 - static_cast<T>(i));
-    C(i) = Kokkos::complex<T>{v, v};
-  });
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(const int i) {
+        T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
+        C(i) = Kokkos::complex<T>{v, v};
+      });
   Kokkos::fence();
 }
 
-template <typename T>
-void complex_min<T>::teardown() {
+template <typename T> void complex_min<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
 template <typename T>
-KOKKOS_INLINE_FUNCTION
-T my_abs (const Kokkos::complex<T>& c) {
-    return sqrt(c.real() * c.real() + c.imag() * c.imag());
+KOKKOS_INLINE_FUNCTION T my_abs(const Kokkos::complex<T> &c) {
+  return sqrt(c.real() * c.real() + c.imag() * c.imag());
 }
 
-template <typename T>
-struct reducer_type {
+template <typename T> struct reducer_type {
   Kokkos::complex<T> c;
 
   KOKKOS_INLINE_FUNCTION
-  reducer_type() {
-    init();
-  }
+  reducer_type() { init(); }
 
   KOKKOS_INLINE_FUNCTION
-  reducer_type(T r, T i) {
-    c = Kokkos::complex<T>{r, i};
-  }
+  reducer_type(T r, T i) { c = Kokkos::complex<T>{r, i}; }
 
   KOKKOS_INLINE_FUNCTION
-  reducer_type(const  reducer_type * rhs) {
-    c = rhs.c;
-  }
+  reducer_type(const reducer_type *rhs) { c = rhs.c; }
 
   KOKKOS_INLINE_FUNCTION
-  void init() {
-    c = Kokkos::complex<T>{0.0, 0.0};
-  }
+  void init() { c = Kokkos::complex<T>{0.0, 0.0}; }
 
   // Fake minimum with += operator
   KOKKOS_INLINE_FUNCTION
-  reducer_type& operator += (const reducer_type& rhs) {
+  reducer_type &operator+=(const reducer_type &rhs) {
     if (abs(c) < abs(rhs.c))
       return *this;
     else
@@ -87,7 +72,7 @@ struct reducer_type {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator += (const volatile reducer_type& rhs) volatile {
+  void operator+=(const volatile reducer_type &rhs) volatile {
     c = (abs(c) < abs(rhs.c)) ? c : rhs.c;
   }
 
@@ -101,70 +86,56 @@ private:
   T abs(const volatile Kokkos::complex<T> &c) volatile {
     return sqrt(c.real() * c.real() + c.imag() * c.imag());
   }
-
 };
 
-
-template <class T, class Space>
-struct ComplexMin {
+template <class T, class Space> struct ComplexMin {
 public:
-  //Required
+  // Required
   typedef ComplexMin reducer;
   typedef reducer_type<T> value_type;
-  typedef Kokkos::View<value_type, Space, Kokkos::MemoryUnmanaged> result_view_type;
+  typedef Kokkos::View<value_type, Space, Kokkos::MemoryUnmanaged>
+      result_view_type;
 
 private:
-  value_type & value;
+  value_type &value;
 
 public:
   KOKKOS_INLINE_FUNCTION
-  ComplexMin(value_type& value_): value(value_) {}
+  ComplexMin(value_type &value_) : value(value_) {}
 
-  //Required
+  // Required
   KOKKOS_INLINE_FUNCTION
-  void join(value_type& dest, const value_type& src)  const {
-    dest += src;
-  }
+  void join(value_type &dest, const value_type &src) const { dest += src; }
 
   KOKKOS_INLINE_FUNCTION
-  void init( value_type& val)  const {
-    val.init();
-  }
+  void init(value_type &val) const { val.init(); }
 
   KOKKOS_INLINE_FUNCTION
-  value_type& reference() const {
-    return value;
-  }
+  value_type &reference() const { return value; }
 
   KOKKOS_INLINE_FUNCTION
-  result_view_type view() const {
-    return result_view_type(&value);
-  }
+  result_view_type view() const { return result_view_type(&value); }
 
   KOKKOS_INLINE_FUNCTION
-  bool references_scalar() const {
-    return true;
-  }
+  bool references_scalar() const { return true; }
 };
 
+template <typename T> std::complex<T> complex_min<T>::run() {
 
-
-template <typename T>
-std::complex<T> complex_min<T>::run() {
-
-  auto& C = pdata->C;
+  auto &C = pdata->C;
 
   auto big = std::numeric_limits<T>::max();
-  reducer_type<T> smallest {big, big};
+  reducer_type<T> smallest{big, big};
 
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, reducer_type<T>& smallest) {
-    smallest.c = (my_abs(smallest.c) < my_abs(C(i))) ? smallest.c : C(i);
-  }, ComplexMin<T, Kokkos::HostSpace>(smallest));
+  Kokkos::parallel_reduce(
+      N,
+      KOKKOS_LAMBDA(const int i, reducer_type<T> &smallest) {
+        smallest.c = (my_abs(smallest.c) < my_abs(C(i))) ? smallest.c : C(i);
+      },
+      ComplexMin<T, Kokkos::HostSpace>(smallest));
 
   return std::complex<T>{smallest.c.real(), smallest.c.imag()};
-
 }
 
 template struct complex_min<double>;
 template struct complex_min<float>;
-

--- a/src/kokkos/complex_min.cpp
+++ b/src/kokkos/complex_min.cpp
@@ -8,7 +8,8 @@
 
 #include "../complex_min.hpp"
 
-template <typename T> struct complex_min<T>::data {
+template <typename T>
+struct complex_min<T>::data {
   Kokkos::View<Kokkos::complex<T> *> C;
 };
 
@@ -17,13 +18,16 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Complex Min is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Complex Min is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T> complex_min<T>::~complex_min() { Kokkos::finalize(); }
+template <typename T>
+complex_min<T>::~complex_min() {
+  Kokkos::finalize();
+}
 
-template <typename T> void complex_min<T>::setup() {
+template <typename T>
+void complex_min<T>::setup() {
 
   pdata->C = Kokkos::View<Kokkos::complex<T> *>("C", N);
 
@@ -37,7 +41,8 @@ template <typename T> void complex_min<T>::setup() {
   Kokkos::fence();
 }
 
-template <typename T> void complex_min<T>::teardown() {
+template <typename T>
+void complex_min<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
@@ -47,7 +52,8 @@ KOKKOS_INLINE_FUNCTION T my_abs(const Kokkos::complex<T> &c) {
   return sqrt(c.real() * c.real() + c.imag() * c.imag());
 }
 
-template <typename T> struct reducer_type {
+template <typename T>
+struct reducer_type {
   Kokkos::complex<T> c;
 
   KOKKOS_INLINE_FUNCTION
@@ -72,29 +78,23 @@ template <typename T> struct reducer_type {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile reducer_type &rhs) volatile {
-    c = (abs(c) < abs(rhs.c)) ? c : rhs.c;
-  }
+  void operator+=(const volatile reducer_type &rhs) volatile { c = (abs(c) < abs(rhs.c)) ? c : rhs.c; }
 
 private:
   KOKKOS_INLINE_FUNCTION
-  T abs(const Kokkos::complex<T> &c) const {
-    return sqrt(c.real() * c.real() + c.imag() * c.imag());
-  }
+  T abs(const Kokkos::complex<T> &c) const { return sqrt(c.real() * c.real() + c.imag() * c.imag()); }
 
   KOKKOS_INLINE_FUNCTION
-  T abs(const volatile Kokkos::complex<T> &c) volatile {
-    return sqrt(c.real() * c.real() + c.imag() * c.imag());
-  }
+  T abs(const volatile Kokkos::complex<T> &c) volatile { return sqrt(c.real() * c.real() + c.imag() * c.imag()); }
 };
 
-template <class T, class Space> struct ComplexMin {
+template <class T, class Space>
+struct ComplexMin {
 public:
   // Required
   typedef ComplexMin reducer;
   typedef reducer_type<T> value_type;
-  typedef Kokkos::View<value_type, Space, Kokkos::MemoryUnmanaged>
-      result_view_type;
+  typedef Kokkos::View<value_type, Space, Kokkos::MemoryUnmanaged> result_view_type;
 
 private:
   value_type &value;
@@ -120,7 +120,8 @@ public:
   bool references_scalar() const { return true; }
 };
 
-template <typename T> std::complex<T> complex_min<T>::run() {
+template <typename T>
+std::complex<T> complex_min<T>::run() {
 
   auto &C = pdata->C;
 

--- a/src/kokkos/complex_min.cpp
+++ b/src/kokkos/complex_min.cpp
@@ -34,7 +34,8 @@ void complex_min<T>::setup() {
   auto C = pdata->C;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) {
+      N,
+      KOKKOS_LAMBDA(const int i) {
         T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
         C(i) = Kokkos::complex<T>{v, v};
       });

--- a/src/kokkos/complex_sum.cpp
+++ b/src/kokkos/complex_sum.cpp
@@ -33,7 +33,8 @@ void complex_sum<T>::setup() {
   auto C = pdata->C;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) {
+      N,
+      KOKKOS_LAMBDA(const int i) {
         T v = 2.0 * 1024.0 / static_cast<T>(N);
         C(i) = Kokkos::complex<T>{v, v};
       });
@@ -54,7 +55,11 @@ std::complex<T> complex_sum<T>::run() {
   Kokkos::complex<T> sum{0.0, 0.0};
 
   Kokkos::parallel_reduce(
-      N, KOKKOS_LAMBDA(const int i, Kokkos::complex<T> &sum) { sum += C(i); }, sum);
+      N,
+      KOKKOS_LAMBDA(const int i, Kokkos::complex<T> &sum) {
+        sum += C(i);
+      },
+      sum);
 
   return std::complex<T>{sum.real(), sum.imag()};
 }

--- a/src/kokkos/complex_sum.cpp
+++ b/src/kokkos/complex_sum.cpp
@@ -7,9 +7,8 @@
 
 #include "../complex_sum.hpp"
 
-template <typename T>
-struct complex_sum<T>::data {
-  Kokkos::View<Kokkos::complex<T>*> C;
+template <typename T> struct complex_sum<T>::data {
+  Kokkos::View<Kokkos::complex<T> *> C;
 };
 
 template <typename T>
@@ -18,49 +17,42 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Complex Sum is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T>
-complex_sum<T>::~complex_sum() {
-  Kokkos::finalize();
-}
+template <typename T> complex_sum<T>::~complex_sum() { Kokkos::finalize(); }
 
-template <typename T>
-void complex_sum<T>::setup() {
+template <typename T> void complex_sum<T>::setup() {
 
-  pdata->C = Kokkos::View<Kokkos::complex<T>*>("C", N);
+  pdata->C = Kokkos::View<Kokkos::complex<T> *>("C", N);
 
   auto C = pdata->C;
 
-  Kokkos::parallel_for(N, KOKKOS_LAMBDA (const int i) {
-    T v = 2.0 * 1024.0 / static_cast<T>(N);
-    C(i) = Kokkos::complex<T>{v, v};
-  });
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(const int i) {
+        T v = 2.0 * 1024.0 / static_cast<T>(N);
+        C(i) = Kokkos::complex<T>{v, v};
+      });
   Kokkos::fence();
 }
 
-template <typename T>
-void complex_sum<T>::teardown() {
+template <typename T> void complex_sum<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
+template <typename T> std::complex<T> complex_sum<T>::run() {
 
-template <typename T>
-std::complex<T> complex_sum<T>::run() {
+  auto &C = pdata->C;
 
-  auto& C = pdata->C;
+  Kokkos::complex<T> sum{0.0, 0.0};
 
-  Kokkos::complex<T> sum {0.0, 0.0};
-
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, Kokkos::complex<T>& sum) {
-    sum += C(i);
-  }, sum);
+  Kokkos::parallel_reduce(
+      N, KOKKOS_LAMBDA(const int i, Kokkos::complex<T> &sum) { sum += C(i); },
+      sum);
 
   return std::complex<T>{sum.real(), sum.imag()};
 }
 
 template struct complex_sum<double>;
 template struct complex_sum<float>;
-

--- a/src/kokkos/complex_sum.cpp
+++ b/src/kokkos/complex_sum.cpp
@@ -7,7 +7,8 @@
 
 #include "../complex_sum.hpp"
 
-template <typename T> struct complex_sum<T>::data {
+template <typename T>
+struct complex_sum<T>::data {
   Kokkos::View<Kokkos::complex<T> *> C;
 };
 
@@ -16,13 +17,16 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Complex Sum is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Complex Sum is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T> complex_sum<T>::~complex_sum() { Kokkos::finalize(); }
+template <typename T>
+complex_sum<T>::~complex_sum() {
+  Kokkos::finalize();
+}
 
-template <typename T> void complex_sum<T>::setup() {
+template <typename T>
+void complex_sum<T>::setup() {
 
   pdata->C = Kokkos::View<Kokkos::complex<T> *>("C", N);
 
@@ -36,20 +40,21 @@ template <typename T> void complex_sum<T>::setup() {
   Kokkos::fence();
 }
 
-template <typename T> void complex_sum<T>::teardown() {
+template <typename T>
+void complex_sum<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> std::complex<T> complex_sum<T>::run() {
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
 
   auto &C = pdata->C;
 
   Kokkos::complex<T> sum{0.0, 0.0};
 
   Kokkos::parallel_reduce(
-      N, KOKKOS_LAMBDA(const int i, Kokkos::complex<T> &sum) { sum += C(i); },
-      sum);
+      N, KOKKOS_LAMBDA(const int i, Kokkos::complex<T> &sum) { sum += C(i); }, sum);
 
   return std::complex<T>{sum.real(), sum.imag()};
 }

--- a/src/kokkos/complex_sum_soa.cpp
+++ b/src/kokkos/complex_sum_soa.cpp
@@ -7,67 +7,65 @@
 
 #include "../complex_sum_soa.hpp"
 
-template <typename T>
-struct complex_sum_soa<T>::data {
-  Kokkos::View<T*> real;
-  Kokkos::View<T*> imag;
+template <typename T> struct complex_sum_soa<T>::data {
+  Kokkos::View<T *> real;
+  Kokkos::View<T *> imag;
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
+complex_sum_soa<T>::complex_sum_soa(long N_)
+    : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Complex Sum SoA is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T>
-complex_sum_soa<T>::~complex_sum_soa() {
+template <typename T> complex_sum_soa<T>::~complex_sum_soa() {
   Kokkos::finalize();
 }
 
-template <typename T>
-void complex_sum_soa<T>::setup() {
+template <typename T> void complex_sum_soa<T>::setup() {
 
-  pdata->real = Kokkos::View<T*>("real", N);
-  pdata->imag = Kokkos::View<T*>("imag", N);
+  pdata->real = Kokkos::View<T *>("real", N);
+  pdata->imag = Kokkos::View<T *>("imag", N);
 
   auto real = pdata->real;
   auto imag = pdata->imag;
 
-  Kokkos::parallel_for(N, KOKKOS_LAMBDA (const int i) {
-    T v = 2.0 * 1024.0 / static_cast<T>(N);
-    real(i) = v;
-    imag(i) = v;
-  });
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(const int i) {
+        T v = 2.0 * 1024.0 / static_cast<T>(N);
+        real(i) = v;
+        imag(i) = v;
+      });
   Kokkos::fence();
 }
 
-template <typename T>
-void complex_sum_soa<T>::teardown() {
+template <typename T> void complex_sum_soa<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
+template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
 
-template <typename T>
-std::tuple<T,T> complex_sum_soa<T>::run() {
-
-  auto& real = pdata->real;
-  auto& imag = pdata->real;
+  auto &real = pdata->real;
+  auto &imag = pdata->real;
 
   T sum_r = 0.0;
   T sum_i = 0.0;
 
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, T& sum_r, T& sum_i) {
-    sum_r += real(i);
-    sum_i += imag(i);
-  }, sum_r,sum_i);
+  Kokkos::parallel_reduce(
+      N,
+      KOKKOS_LAMBDA(const int i, T &sum_r, T &sum_i) {
+        sum_r += real(i);
+        sum_i += imag(i);
+      },
+      sum_r, sum_i);
 
   return {sum_r, sum_i};
 }
 
 template struct complex_sum_soa<double>;
 template struct complex_sum_soa<float>;
-

--- a/src/kokkos/complex_sum_soa.cpp
+++ b/src/kokkos/complex_sum_soa.cpp
@@ -7,26 +7,27 @@
 
 #include "../complex_sum_soa.hpp"
 
-template <typename T> struct complex_sum_soa<T>::data {
+template <typename T>
+struct complex_sum_soa<T>::data {
   Kokkos::View<T *> real;
   Kokkos::View<T *> imag;
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_)
-    : N(N_), pdata{std::make_unique<data>()} {
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Complex Sum SoA is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Complex Sum SoA is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-template <typename T> complex_sum_soa<T>::~complex_sum_soa() {
+template <typename T>
+complex_sum_soa<T>::~complex_sum_soa() {
   Kokkos::finalize();
 }
 
-template <typename T> void complex_sum_soa<T>::setup() {
+template <typename T>
+void complex_sum_soa<T>::setup() {
 
   pdata->real = Kokkos::View<T *>("real", N);
   pdata->imag = Kokkos::View<T *>("imag", N);
@@ -43,12 +44,14 @@ template <typename T> void complex_sum_soa<T>::setup() {
   Kokkos::fence();
 }
 
-template <typename T> void complex_sum_soa<T>::teardown() {
+template <typename T>
+void complex_sum_soa<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
+template <typename T>
+std::tuple<T, T> complex_sum_soa<T>::run() {
 
   auto &real = pdata->real;
   auto &imag = pdata->real;

--- a/src/kokkos/complex_sum_soa.cpp
+++ b/src/kokkos/complex_sum_soa.cpp
@@ -36,7 +36,8 @@ void complex_sum_soa<T>::setup() {
   auto imag = pdata->imag;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) {
+      N,
+      KOKKOS_LAMBDA(const int i) {
         T v = 2.0 * 1024.0 / static_cast<T>(N);
         real(i) = v;
         imag(i) = v;

--- a/src/kokkos/describe.cpp
+++ b/src/kokkos/describe.cpp
@@ -16,8 +16,7 @@ describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Describe is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Describe is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
 describe::~describe() { Kokkos::finalize(); }
@@ -29,9 +28,7 @@ void describe::setup() {
   auto &D = pdata->D;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) {
-        D(i) = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
-      });
+      N, KOKKOS_LAMBDA(const int i) { D(i) = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
   Kokkos::fence();
 }
 
@@ -55,8 +52,7 @@ describe::result describe::run() {
 
   Kokkos::parallel_reduce(
       N,
-      KOKKOS_LAMBDA(const int i, double &mean, double &lost, double &min,
-                    double &max) {
+      KOKKOS_LAMBDA(const int i, double &mean, double &lost, double &min, double &max) {
         // Mean calculation
         double val = D(i) / static_cast<double>(N);
         double t = mean + val;
@@ -77,10 +73,7 @@ describe::result describe::run() {
   double std = 0.0;
 
   Kokkos::parallel_reduce(
-      N,
-      KOKKOS_LAMBDA(const int i, double &std) {
-        std += ((D(i) - mean) * (D(i) - mean)) / static_cast<double>(N);
-      },
+      N, KOKKOS_LAMBDA(const int i, double &std) { std += ((D(i) - mean) * (D(i) - mean)) / static_cast<double>(N); },
       std);
 
   std = std::sqrt(std);

--- a/src/kokkos/describe.cpp
+++ b/src/kokkos/describe.cpp
@@ -9,7 +9,7 @@
 #include "../describe.hpp"
 
 struct describe::data {
-  Kokkos::View<double*> D;
+  Kokkos::View<double *> D;
 };
 
 describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -17,22 +17,21 @@ describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Describe is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-describe::~describe() {
-  Kokkos::finalize();
-}
+describe::~describe() { Kokkos::finalize(); }
 
 void describe::setup() {
 
-  pdata->D = Kokkos::View<double*>("D", N);
+  pdata->D = Kokkos::View<double *>("D", N);
 
-  auto& D = pdata->D;
+  auto &D = pdata->D;
 
-  Kokkos::parallel_for(N, KOKKOS_LAMBDA (const int i) {
-    D(i) = fabs(static_cast<double>(N)/2.0 - static_cast<double>(i));
-  });
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(const int i) {
+        D(i) = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
+      });
   Kokkos::fence();
 }
 
@@ -43,7 +42,7 @@ void describe::teardown() {
 
 describe::result describe::run() {
 
-  auto& D = pdata->D;
+  auto &D = pdata->D;
 
   long count = N;
 
@@ -54,38 +53,37 @@ describe::result describe::run() {
   double min = std::numeric_limits<double>::max();
   double max = std::numeric_limits<double>::min();
 
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, double& mean, double& lost, double &min, double& max) {
-    // Mean calculation
-    double val = D(i) / static_cast<double>(N);
-    double t = mean + val;
-    if (fabs(mean) >= val)
-      lost += (mean - t) + val;
-    else
-      lost += (val - t) + mean;
+  Kokkos::parallel_reduce(
+      N,
+      KOKKOS_LAMBDA(const int i, double &mean, double &lost, double &min,
+                    double &max) {
+        // Mean calculation
+        double val = D(i) / static_cast<double>(N);
+        double t = mean + val;
+        if (fabs(mean) >= val)
+          lost += (mean - t) + val;
+        else
+          lost += (val - t) + mean;
 
-    mean += val;
+        mean += val;
 
-
-    min = (min < D(i)) ? min : D(i);
-    max = (max > D(i)) ? max : D(i);
-  }, mean, lost, Kokkos::Min<double>(min), Kokkos::Max<double>(max));
+        min = (min < D(i)) ? min : D(i);
+        max = (max > D(i)) ? max : D(i);
+      },
+      mean, lost, Kokkos::Min<double>(min), Kokkos::Max<double>(max));
 
   mean = mean + lost;
 
   double std = 0.0;
 
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, double& std) {
-    std += ((D(i) - mean) * (D(i) - mean)) / static_cast<double>(N);
-  }, std);
+  Kokkos::parallel_reduce(
+      N,
+      KOKKOS_LAMBDA(const int i, double &std) {
+        std += ((D(i) - mean) * (D(i) - mean)) / static_cast<double>(N);
+      },
+      std);
 
   std = std::sqrt(std);
 
-  return {
-    .count = count,
-    .mean = mean,
-    .std = std,
-    .min = min,
-    .max = max
-  };
+  return {.count = count, .mean = mean, .std = std, .min = min, .max = max};
 }
-

--- a/src/kokkos/describe.cpp
+++ b/src/kokkos/describe.cpp
@@ -28,7 +28,10 @@ void describe::setup() {
   auto &D = pdata->D;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) { D(i) = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
+      N,
+      KOKKOS_LAMBDA(const int i) {
+        D(i) = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
+      });
   Kokkos::fence();
 }
 

--- a/src/kokkos/dot.cpp
+++ b/src/kokkos/dot.cpp
@@ -8,8 +8,8 @@
 #include <Kokkos_Core.hpp>
 
 struct dot::data {
-  Kokkos::View<double*> A;
-  Kokkos::View<double*> B;
+  Kokkos::View<double *> A;
+  Kokkos::View<double *> B;
 };
 
 dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -17,17 +17,15 @@ dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Dot is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-dot::~dot() {
-  Kokkos::finalize();
-}
+dot::~dot() { Kokkos::finalize(); }
 
 void dot::setup() {
 
-  pdata->A = Kokkos::View<double*>("A", N);
-  pdata->B = Kokkos::View<double*>("B", N);
+  pdata->A = Kokkos::View<double *>("A", N);
+  pdata->B = Kokkos::View<double *>("B", N);
 
   auto A = pdata->A;
   auto B = pdata->B;
@@ -35,10 +33,11 @@ void dot::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const long N = this->N;
 
-  Kokkos::parallel_for(N, KOKKOS_LAMBDA (const int i) {
-    A(i) = 1.0 * 1024.0 / static_cast<double>(N);
-    B(i) = 2.0 * 1024.0 / static_cast<double>(N);
-  });
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(const int i) {
+        A(i) = 1.0 * 1024.0 / static_cast<double>(N);
+        B(i) = 2.0 * 1024.0 / static_cast<double>(N);
+      });
   Kokkos::fence();
 }
 
@@ -48,15 +47,13 @@ void dot::teardown() {
 }
 
 double dot::run() {
-  auto& A = pdata->A;
-  auto& B = pdata->B;
+  auto &A = pdata->A;
+  auto &B = pdata->B;
 
   double sum = 0.0;
 
-  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA (const int i, double& sum) {
-    sum += A(i) * B(i);
-  }, sum);
+  Kokkos::parallel_reduce(
+      N, KOKKOS_LAMBDA(const int i, double &sum) { sum += A(i) * B(i); }, sum);
 
   return sum;
 }
-

--- a/src/kokkos/dot.cpp
+++ b/src/kokkos/dot.cpp
@@ -33,7 +33,8 @@ void dot::setup() {
   const long N = this->N;
 
   Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(const int i) {
+      N,
+      KOKKOS_LAMBDA(const int i) {
         A(i) = 1.0 * 1024.0 / static_cast<double>(N);
         B(i) = 2.0 * 1024.0 / static_cast<double>(N);
       });
@@ -52,7 +53,8 @@ double dot::run() {
   double sum = 0.0;
 
   Kokkos::parallel_reduce(
-      N, KOKKOS_LAMBDA(const int i, double &sum) { sum += A(i) * B(i); }, sum);
+      N,
+      KOKKOS_LAMBDA(const int i, double &sum) { sum += A(i) * B(i); }, sum);
 
   return sum;
 }

--- a/src/kokkos/dot.cpp
+++ b/src/kokkos/dot.cpp
@@ -16,8 +16,7 @@ dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Dot is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Dot is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
 dot::~dot() { Kokkos::finalize(); }

--- a/src/kokkos/field_summary.cpp
+++ b/src/kokkos/field_summary.cpp
@@ -20,8 +20,7 @@ field_summary::field_summary() : pdata{std::make_unique<data>()} {
   Kokkos::initialize();
 
   // Print out a (mangled) name of what backend Kokkos is using
-  std::cout << "Field Summary is using Kokkos with "
-            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+  std::cout << "Field Summary is using Kokkos with " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
 field_summary::~field_summary() { Kokkos::finalize(); }
@@ -47,8 +46,7 @@ void field_summary::setup() {
   const double dy = 10.0 / static_cast<double>(ny);
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
-      KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}), KOKKOS_LAMBDA(const int j, const int k) {
         volume(j, k) = dx * dy;
         density(j, k) = 0.2;
         energy(j, k) = 1.0;
@@ -56,16 +54,14 @@ void field_summary::setup() {
       });
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx / 2, ny / 5}),
-      KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx / 2, ny / 5}), KOKKOS_LAMBDA(const int j, const int k) {
         density(j, k) = 1.0;
         energy(j, k) = 2.5;
         pressure(j, k) = (1.4 - 1.0) * density(j, k) * energy(j, k);
       });
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx + 1, ny + 1}),
-      KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx + 1, ny + 1}), KOKKOS_LAMBDA(const int j, const int k) {
         xvel(j, k) = 0.0;
         yvel(j, k) = 0.0;
       });
@@ -96,13 +92,11 @@ field_summary::reduction_vars field_summary::run() {
 
   Kokkos::parallel_reduce(
       Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
-      KOKKOS_LAMBDA(const int j, const int k, double &vol, double &mass,
-                    double &ie, double &ke, double &press) {
+      KOKKOS_LAMBDA(const int j, const int k, double &vol, double &mass, double &ie, double &ke, double &press) {
         double vsqrd = 0.0;
         for (int kv = k; kv <= k + 1; ++kv) {
           for (int jv = j; jv <= j + 1; ++jv) {
-            vsqrd += 0.25 * (xvel(jv, kv) * xvel(jv, kv) +
-                             yvel(jv, kv) * yvel(jv, kv));
+            vsqrd += 0.25 * (xvel(jv, kv) * xvel(jv, kv) + yvel(jv, kv) * yvel(jv, kv));
           }
         }
         double cell_volume = volume(j, k);

--- a/src/kokkos/field_summary.cpp
+++ b/src/kokkos/field_summary.cpp
@@ -46,7 +46,8 @@ void field_summary::setup() {
   const double dy = 10.0 / static_cast<double>(ny);
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}), KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
+      KOKKOS_LAMBDA(const int j, const int k) {
         volume(j, k) = dx * dy;
         density(j, k) = 0.2;
         energy(j, k) = 1.0;
@@ -54,14 +55,16 @@ void field_summary::setup() {
       });
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx / 2, ny / 5}), KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx / 2, ny / 5}),
+      KOKKOS_LAMBDA(const int j, const int k) {
         density(j, k) = 1.0;
         energy(j, k) = 2.5;
         pressure(j, k) = (1.4 - 1.0) * density(j, k) * energy(j, k);
       });
 
   Kokkos::parallel_for(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx + 1, ny + 1}), KOKKOS_LAMBDA(const int j, const int k) {
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx + 1, ny + 1}),
+      KOKKOS_LAMBDA(const int j, const int k) {
         xvel(j, k) = 0.0;
         yvel(j, k) = 0.0;
       });

--- a/src/kokkos/field_summary.cpp
+++ b/src/kokkos/field_summary.cpp
@@ -8,12 +8,12 @@
 #include <Kokkos_Core.hpp>
 
 struct field_summary::data {
-  Kokkos::View<double**> xvel;
-  Kokkos::View<double**> yvel;
-  Kokkos::View<double**> volume;
-  Kokkos::View<double**> density;
-  Kokkos::View<double**> energy;
-  Kokkos::View<double**> pressure;
+  Kokkos::View<double **> xvel;
+  Kokkos::View<double **> yvel;
+  Kokkos::View<double **> volume;
+  Kokkos::View<double **> density;
+  Kokkos::View<double **> energy;
+  Kokkos::View<double **> pressure;
 };
 
 field_summary::field_summary() : pdata{std::make_unique<data>()} {
@@ -21,56 +21,56 @@ field_summary::field_summary() : pdata{std::make_unique<data>()} {
 
   // Print out a (mangled) name of what backend Kokkos is using
   std::cout << "Field Summary is using Kokkos with "
-    << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+            << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
 }
 
-field_summary::~field_summary() {
-  Kokkos::finalize();
-}
+field_summary::~field_summary() { Kokkos::finalize(); }
 
 void field_summary::setup() {
   // Allocate arrays
-  pdata->xvel = Kokkos::View<double**>("xvel", nx+1, ny+1);
-  pdata->yvel = Kokkos::View<double**>("yvel", nx+1, ny+1);
-  pdata->volume = Kokkos::View<double**>("volume", nx, ny);
-  pdata->density = Kokkos::View<double**>("density", nx, ny);
-  pdata->energy = Kokkos::View<double**>("energy", nx, ny);
-  pdata->pressure = Kokkos::View<double**>("pressure", nx, ny);
+  pdata->xvel = Kokkos::View<double **>("xvel", nx + 1, ny + 1);
+  pdata->yvel = Kokkos::View<double **>("yvel", nx + 1, ny + 1);
+  pdata->volume = Kokkos::View<double **>("volume", nx, ny);
+  pdata->density = Kokkos::View<double **>("density", nx, ny);
+  pdata->energy = Kokkos::View<double **>("energy", nx, ny);
+  pdata->pressure = Kokkos::View<double **>("pressure", nx, ny);
 
-  auto& xvel = pdata->xvel;
-  auto& yvel = pdata->yvel;
-  auto& volume = pdata->volume;
-  auto& density = pdata->density;
-  auto& energy = pdata->energy;
-  auto& pressure = pdata->pressure;
+  auto &xvel = pdata->xvel;
+  auto &yvel = pdata->yvel;
+  auto &volume = pdata->volume;
+  auto &density = pdata->density;
+  auto &energy = pdata->energy;
+  auto &pressure = pdata->pressure;
 
   // Initalise arrays
-  const double dx = 10.0/static_cast<double>(nx);
-  const double dy = 10.0/static_cast<double>(ny);
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
 
-  Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {nx,ny}),
-    KOKKOS_LAMBDA (const int j, const int k) {
-      volume(j,k) = dx * dy;
-      density(j,k) = 0.2;
-      energy(j,k) = 1.0;
-      pressure(j,k) = (1.4-1.0) * density(j,k) * energy(j,k);
-    });
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
+      KOKKOS_LAMBDA(const int j, const int k) {
+        volume(j, k) = dx * dy;
+        density(j, k) = 0.2;
+        energy(j, k) = 1.0;
+        pressure(j, k) = (1.4 - 1.0) * density(j, k) * energy(j, k);
+      });
 
-  Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {nx/2,ny/5}),
-    KOKKOS_LAMBDA (const int j, const int k) {
-      density(j,k) = 1.0;
-      energy(j,k) = 2.5;
-      pressure(j,k) = (1.4-1.0) * density(j,k) * energy(j,k);
-    });
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx / 2, ny / 5}),
+      KOKKOS_LAMBDA(const int j, const int k) {
+        density(j, k) = 1.0;
+        energy(j, k) = 2.5;
+        pressure(j, k) = (1.4 - 1.0) * density(j, k) * energy(j, k);
+      });
 
-  Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {nx+1,ny+1}),
-    KOKKOS_LAMBDA (const int j, const int k) {
-      xvel(j,k) = 0.0;
-      yvel(j,k) = 0.0;
-    });
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx + 1, ny + 1}),
+      KOKKOS_LAMBDA(const int j, const int k) {
+        xvel(j, k) = 0.0;
+        yvel(j, k) = 0.0;
+      });
 
   Kokkos::fence();
-
 }
 
 void field_summary::teardown() {
@@ -80,12 +80,12 @@ void field_summary::teardown() {
 
 field_summary::reduction_vars field_summary::run() {
 
-  auto& xvel = pdata->xvel;
-  auto& yvel = pdata->yvel;
-  auto& volume = pdata->volume;
-  auto& density = pdata->density;
-  auto& energy = pdata->energy;
-  auto& pressure = pdata->pressure;
+  auto &xvel = pdata->xvel;
+  auto &yvel = pdata->yvel;
+  auto &volume = pdata->volume;
+  auto &density = pdata->density;
+  auto &energy = pdata->energy;
+  auto &pressure = pdata->pressure;
 
   // Reduction variables
   double vol = 0.0;
@@ -94,25 +94,26 @@ field_summary::reduction_vars field_summary::run() {
   double ke = 0.0;
   double press = 0.0;
 
-
-  Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {nx,ny}),
-    KOKKOS_LAMBDA (const int j, const int k, double& vol, double& mass, double& ie, double& ke, double& press) {
-      double vsqrd = 0.0;
-      for (int kv = k; kv <= k+1; ++kv) {
-        for (int jv = j; jv <= j+1; ++jv) {
-          vsqrd += 0.25 * (xvel(jv,kv) * xvel(jv,kv) + yvel(jv,kv) * yvel(jv,kv));
+  Kokkos::parallel_reduce(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
+      KOKKOS_LAMBDA(const int j, const int k, double &vol, double &mass,
+                    double &ie, double &ke, double &press) {
+        double vsqrd = 0.0;
+        for (int kv = k; kv <= k + 1; ++kv) {
+          for (int jv = j; jv <= j + 1; ++jv) {
+            vsqrd += 0.25 * (xvel(jv, kv) * xvel(jv, kv) +
+                             yvel(jv, kv) * yvel(jv, kv));
+          }
         }
-      }
-      double cell_volume = volume(j,k);
-      double cell_mass = cell_volume * density(j,k);
-      vol += cell_volume;
-      mass += cell_mass;
-      ie += cell_mass * energy(j,k);
-      ke += cell_mass * 0.5 * vsqrd;
-      press += cell_volume * pressure(j,k);
-    }, vol, mass, ie, ke, press);
+        double cell_volume = volume(j, k);
+        double cell_mass = cell_volume * density(j, k);
+        vol += cell_volume;
+        mass += cell_mass;
+        ie += cell_mass * energy(j, k);
+        ke += cell_mass * 0.5 * vsqrd;
+        press += cell_volume * pressure(j, k);
+      },
+      vol, mass, ie, ke, press);
 
   return {vol, mass, ie, ke, press};
 }
-
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,14 +20,7 @@ const auto LINE = "------------------------------------------------------------"
 #include "dot.hpp"
 #include "field_summary.hpp"
 
-enum class Benchmark {
-  dot,
-  complex_sum,
-  complex_sum_soa,
-  complex_min,
-  field_summary,
-  describe
-};
+enum class Benchmark { dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe };
 
 // Choose the benchmark based on the input argument given from the command line
 Benchmark select_benchmark(const std::string name) {
@@ -75,8 +68,7 @@ double elapsed(std::chrono::high_resolution_clock::time_point start,
 }
 
 // Print timings for a benchmark
-void print_timing(const char *name, const double constructor,
-                  const double setup, const double run, const double check,
+void print_timing(const char *name, const double constructor, const double setup, const double run, const double check,
                   const double teardown, const double gibibytes) {
   std::cout << std::endl
             << " " << name << std::endl
@@ -97,8 +89,7 @@ int main(int argc, char *argv[]) {
 
   // Report version
   std::cout << "Everything's Reduced "
-            << "(v" << Reduced_VERSION_MAJOR << "." << Reduced_VERSION_MINOR
-            << ")" << std::endl
+            << "(v" << Reduced_VERSION_MAJOR << "." << Reduced_VERSION_MINOR << ")" << std::endl
             << std::endl;
 
   // Check command line arguments
@@ -137,14 +128,12 @@ int main(int argc, char *argv[]) {
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - dotty.expect()) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r - dotty.expect()) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Dot: result incorrect" << std::endl
                 << "Expected: " << dotty.expect() << std::endl
                 << "Result: " << r << std::endl
                 << "Difference: " << std::abs(r - dotty.expect()) << std::endl
-                << "Eps: " << std::numeric_limits<double>::epsilon()
-                << std::endl;
+                << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -152,10 +141,9 @@ int main(int argc, char *argv[]) {
     dotty.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Dot Product", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), dotty.gibibytes());
+    print_timing("Dot Product", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 dotty.gibibytes());
 
   }
 
@@ -180,14 +168,12 @@ int main(int argc, char *argv[]) {
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - csum.expect()) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r - csum.expect()) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Sum: result incorrect" << std::endl
                 << "Expected: " << csum.expect() << std::endl
                 << "Result: " << r << std::endl
                 << "Difference: " << std::abs(r - csum.expect()) << std::endl
-                << "Eps: " << std::numeric_limits<double>::epsilon()
-                << std::endl;
+                << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -195,10 +181,9 @@ int main(int argc, char *argv[]) {
     csum.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Sum", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), csum.gibibytes());
+    print_timing("Complex Sum", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 csum.gibibytes());
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -222,22 +207,14 @@ int main(int argc, char *argv[]) {
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(std::get<0>(r) - std::get<0>(csum.expect())) >
-            std::numeric_limits<double>::epsilon() * 100.0 ||
-        std::abs(std::get<1>(r) - std::get<1>(csum.expect())) >
-            std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(std::get<0>(r) - std::get<0>(csum.expect())) > std::numeric_limits<double>::epsilon() * 100.0 ||
+        std::abs(std::get<1>(r) - std::get<1>(csum.expect())) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Sum SoA: result incorrect" << std::endl
-                << "Expected: " << std::get<0>(csum.expect()) << "+ i"
-                << std::get<1>(csum.expect()) << std::endl
-                << "Result:   " << std::get<0>(r) << "+ i" << std::get<1>(r)
-                << std::endl
-                << "Difference: "
-                << std::abs(std::get<0>(r) - std::get<0>(csum.expect()))
-                << " and "
-                << std::abs(std::get<1>(r) - std::get<1>(csum.expect()))
-                << std::endl
-                << "Eps: " << std::numeric_limits<double>::epsilon()
-                << std::endl;
+                << "Expected: " << std::get<0>(csum.expect()) << "+ i" << std::get<1>(csum.expect()) << std::endl
+                << "Result:   " << std::get<0>(r) << "+ i" << std::get<1>(r) << std::endl
+                << "Difference: " << std::abs(std::get<0>(r) - std::get<0>(csum.expect())) << " and "
+                << std::abs(std::get<1>(r) - std::get<1>(csum.expect())) << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -245,10 +222,9 @@ int main(int argc, char *argv[]) {
     csum.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Sum", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), csum.gibibytes());
+    print_timing("Complex Sum", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 csum.gibibytes());
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -272,14 +248,12 @@ int main(int argc, char *argv[]) {
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - cmin.expect()) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r - cmin.expect()) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Min: result incorrect" << std::endl
                 << "Expected: " << cmin.expect() << std::endl
                 << "Result: " << r << std::endl
                 << "Difference: " << std::abs(r - cmin.expect()) << std::endl
-                << "Eps: " << std::numeric_limits<double>::epsilon()
-                << std::endl;
+                << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -287,10 +261,9 @@ int main(int argc, char *argv[]) {
     cmin.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Min", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), cmin.gibibytes());
+    print_timing("Complex Min", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 cmin.gibibytes());
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -316,15 +289,13 @@ int main(int argc, char *argv[]) {
       std::cerr << "Field Summary: vol result incorrect" << std::endl
                 << "Expected: " << expected.vol << std::endl
                 << "Result: " << r.vol << std::endl
-                << "Difference: " << std::abs(r.vol - expected.vol)
-                << std::endl;
+                << "Difference: " << std::abs(r.vol - expected.vol) << std::endl;
     }
     if (std::abs(r.mass - expected.mass) > 1.0E-8) {
       std::cerr << "Field Summary: mass result incorrect" << std::endl
                 << "Expected: " << expected.mass << std::endl
                 << "Result: " << r.mass << std::endl
-                << "Difference: " << std::abs(r.mass - expected.mass)
-                << std::endl;
+                << "Difference: " << std::abs(r.mass - expected.mass) << std::endl;
     }
     if (std::abs(r.ie - expected.ie) > 1.0E-8) {
       std::cerr << "Field Summary: ie result incorrect" << std::endl
@@ -342,8 +313,7 @@ int main(int argc, char *argv[]) {
       std::cerr << "Field Summary: press result incorrect" << std::endl
                 << "Expected: " << expected.press << std::endl
                 << "Result: " << r.press << std::endl
-                << "Difference: " << std::abs(r.press - expected.press)
-                << std::endl;
+                << "Difference: " << std::abs(r.press - expected.press) << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -351,10 +321,9 @@ int main(int argc, char *argv[]) {
     summary.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Field Summary", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), summary.gibibytes());
+    print_timing("Field Summary", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 summary.gibibytes());
 
   }
 
@@ -380,13 +349,11 @@ int main(int argc, char *argv[]) {
     // Check solution
     auto check_start = clock::now();
     describe::result expected = d.expect();
-    if (std::abs(r.count - expected.count) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r.count - expected.count) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: count result incorrect" << std::endl
                 << "Expected: " << expected.count << std::endl
                 << "Result: " << r.count << std::endl
-                << "Difference: " << std::abs(r.count - expected.count)
-                << std::endl;
+                << "Difference: " << std::abs(r.count - expected.count) << std::endl;
     }
     // Check this one to E-12 as computed analytically rather than large sum,
     // and FP errors seem to accumulate
@@ -394,8 +361,7 @@ int main(int argc, char *argv[]) {
       std::cerr << "Describe: mean result incorrect" << std::endl
                 << "Expected: " << expected.mean << std::endl
                 << "Result: " << r.mean << std::endl
-                << "Difference: " << std::abs(r.mean - expected.mean)
-                << std::endl;
+                << "Difference: " << std::abs(r.mean - expected.mean) << std::endl;
     }
     // The Sqrt operation drastically increases the error, so check to 4 d.p
     // This is equiv to checking the variance with a tolerance of 1.E-8
@@ -403,24 +369,19 @@ int main(int argc, char *argv[]) {
       std::cerr << "Describe: std result incorrect" << std::endl
                 << "Expected: " << std::fixed << expected.std << std::endl
                 << "Result: " << std::fixed << r.std << std::endl
-                << "Difference: " << std::abs(r.std - expected.std)
-                << std::endl;
+                << "Difference: " << std::abs(r.std - expected.std) << std::endl;
     }
-    if (std::abs(r.min - expected.min) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r.min - expected.min) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: min result incorrect" << std::endl
                 << "Expected: " << expected.min << std::endl
                 << "Result: " << r.min << std::endl
-                << "Difference: " << std::abs(r.min - expected.min)
-                << std::endl;
+                << "Difference: " << std::abs(r.min - expected.min) << std::endl;
     }
-    if (std::abs(r.max - expected.max) >
-        std::numeric_limits<double>::epsilon() * 100.0) {
+    if (std::abs(r.max - expected.max) > std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: max result incorrect" << std::endl
                 << "Expected: " << expected.max << std::endl
                 << "Result: " << r.max << std::endl
-                << "Difference: " << std::abs(r.max - expected.max)
-                << std::endl;
+                << "Difference: " << std::abs(r.max - expected.max) << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -428,10 +389,9 @@ int main(int argc, char *argv[]) {
     d.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Describe", elapsed(construct_start, construct_stop),
-                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
-                 elapsed(check_start, check_stop),
-                 elapsed(teardown_start, teardown_stop), d.gibibytes());
+    print_timing("Describe", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 d.gibibytes());
   }
 
   return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,35 +1,49 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
-#include <iostream>
-#include <limits>
 #include <chrono>
 #include <complex>
+#include <iostream>
+#include <limits>
 #include <string>
 
-const auto LINE = "--------------------------------------------------------------------------------";
+const auto LINE = "------------------------------------------------------------"
+                  "--------------------";
 
 #include "config.hpp"
 
 // Benchmarks:
-#include "dot.hpp"
+#include "complex_min.hpp"
 #include "complex_sum.hpp"
 #include "complex_sum_soa.hpp"
-#include "complex_min.hpp"
-#include "field_summary.hpp"
 #include "describe.hpp"
+#include "dot.hpp"
+#include "field_summary.hpp"
 
-enum class Benchmark {dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe};
+enum class Benchmark {
+  dot,
+  complex_sum,
+  complex_sum_soa,
+  complex_min,
+  field_summary,
+  describe
+};
 
 // Choose the benchmark based on the input argument given from the command line
 Benchmark select_benchmark(const std::string name) {
 
-  if (name == "dot") return Benchmark::dot;
-  else if (name == "complex_sum") return Benchmark::complex_sum;
-  else if (name == "complex_sum_soa") return Benchmark::complex_sum_soa;
-  else if (name == "complex_min") return Benchmark::complex_min;
-  else if (name == "field_summary") return Benchmark::field_summary;
-  else if (name == "describe") return Benchmark::describe;
+  if (name == "dot")
+    return Benchmark::dot;
+  else if (name == "complex_sum")
+    return Benchmark::complex_sum;
+  else if (name == "complex_sum_soa")
+    return Benchmark::complex_sum_soa;
+  else if (name == "complex_min")
+    return Benchmark::complex_min;
+  else if (name == "field_summary")
+    return Benchmark::field_summary;
+  else if (name == "describe")
+    return Benchmark::describe;
   else {
     std::cerr << "Invalid benchmark: " << name << std::endl;
     exit(EXIT_FAILURE);
@@ -54,21 +68,24 @@ long get_problem_size(const std::string option) {
 }
 
 // Return elapsed time
-double elapsed(std::chrono::high_resolution_clock::time_point start, std::chrono::high_resolution_clock::time_point stop) {
+double elapsed(std::chrono::high_resolution_clock::time_point start,
+               std::chrono::high_resolution_clock::time_point stop) {
   using timing = std::chrono::duration<double, std::milli>;
-  return timing{stop-start}.count();
+  return timing{stop - start}.count();
 }
 
 // Print timings for a benchmark
-void print_timing(const char *name, const double constructor, const double setup, const double run, const double check, const double teardown) {
-    std::cout << std::endl
-      << " " << name << std::endl
-      << "  Constructor: " << constructor << std::endl
-      << "  Setup:       " << setup << std::endl
-      << "  Run:         " << run << std::endl
-      << "  Verify:      " << check << std::endl
-      << "  Teardown:    " << teardown << std::endl
-      << LINE << std::endl;
+void print_timing(const char *name, const double constructor,
+                  const double setup, const double run, const double check,
+                  const double teardown) {
+  std::cout << std::endl
+            << " " << name << std::endl
+            << "  Constructor: " << constructor << std::endl
+            << "  Setup:       " << setup << std::endl
+            << "  Run:         " << run << std::endl
+            << "  Verify:      " << check << std::endl
+            << "  Teardown:    " << teardown << std::endl
+            << LINE << std::endl;
 }
 
 int main(int argc, char *argv[]) {
@@ -78,15 +95,18 @@ int main(int argc, char *argv[]) {
 
   // Report version
   std::cout << "Everything's Reduced "
-    << "(v" << Reduced_VERSION_MAJOR << "." << Reduced_VERSION_MINOR << ")"
-    << std::endl << std::endl;
+            << "(v" << Reduced_VERSION_MAJOR << "." << Reduced_VERSION_MINOR
+            << ")" << std::endl
+            << std::endl;
 
   // Check command line arguments
   if (argc < 2) {
-    std::cerr
-      << "Usage: " << argv[0] << " <benchmark> <options>" << std::endl << std::endl
-      <<    "Valid benchmarks:" << std::endl
-      <<    "  dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " <benchmark> <options>" << std::endl
+              << std::endl
+              << "Valid benchmarks:" << std::endl
+              << "  dot, complex_sum, complex_sum_soa, complex_min, "
+                 "field_summary, describe"
+              << std::endl;
     exit(EXIT_FAILURE);
   }
 
@@ -115,12 +135,14 @@ int main(int argc, char *argv[]) {
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - dotty.expect()) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r - dotty.expect()) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Dot: result incorrect" << std::endl
-        << "Expected: " << dotty.expect() << std::endl
-        << "Result: " << r << std::endl
-        << "Difference: " << std::abs(r - dotty.expect()) << std::endl
-        << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
+                << "Expected: " << dotty.expect() << std::endl
+                << "Result: " << r << std::endl
+                << "Difference: " << std::abs(r - dotty.expect()) << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon()
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -128,13 +150,10 @@ int main(int argc, char *argv[]) {
     dotty.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Dot Product",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
+    print_timing("Dot Product", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -152,19 +171,20 @@ int main(int argc, char *argv[]) {
     csum.setup();
     auto setup_stop = clock::now();
 
-
     auto run_start = clock::now();
     std::complex<double> r = csum.run();
     auto run_stop = clock::now();
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - csum.expect()) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r - csum.expect()) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Sum: result incorrect" << std::endl
-        << "Expected: " << csum.expect() << std::endl
-        << "Result: " << r << std::endl
-        << "Difference: " << std::abs(r - csum.expect()) << std::endl
-        << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
+                << "Expected: " << csum.expect() << std::endl
+                << "Result: " << r << std::endl
+                << "Difference: " << std::abs(r - csum.expect()) << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon()
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -172,13 +192,10 @@ int main(int argc, char *argv[]) {
     csum.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Sum",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
+    print_timing("Complex Sum", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -196,21 +213,28 @@ int main(int argc, char *argv[]) {
     csum.setup();
     auto setup_stop = clock::now();
 
-
     auto run_start = clock::now();
     std::tuple<double, double> r = csum.run();
     auto run_stop = clock::now();
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(std::get<0>(r) - std::get<0>(csum.expect())) > std::numeric_limits<double>::epsilon()*100.0 ||
-        std::abs(std::get<1>(r) - std::get<1>(csum.expect())) > std::numeric_limits<double>::epsilon()*100.0
-      ) {
+    if (std::abs(std::get<0>(r) - std::get<0>(csum.expect())) >
+            std::numeric_limits<double>::epsilon() * 100.0 ||
+        std::abs(std::get<1>(r) - std::get<1>(csum.expect())) >
+            std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Sum SoA: result incorrect" << std::endl
-        << "Expected: " << std::get<0>(csum.expect()) << "+ i" << std::get<1>(csum.expect()) << std::endl
-        << "Result:   " << std::get<0>(r) << "+ i" << std::get<1>(r) << std::endl
-        << "Difference: " << std::abs(std::get<0>(r) - std::get<0>(csum.expect())) << " and " << std::abs(std::get<1>(r) - std::get<1>(csum.expect())) << std::endl
-        << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
+                << "Expected: " << std::get<0>(csum.expect()) << "+ i"
+                << std::get<1>(csum.expect()) << std::endl
+                << "Result:   " << std::get<0>(r) << "+ i" << std::get<1>(r)
+                << std::endl
+                << "Difference: "
+                << std::abs(std::get<0>(r) - std::get<0>(csum.expect()))
+                << " and "
+                << std::abs(std::get<1>(r) - std::get<1>(csum.expect()))
+                << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon()
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -218,13 +242,10 @@ int main(int argc, char *argv[]) {
     csum.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Sum",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
+    print_timing("Complex Sum", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -242,19 +263,20 @@ int main(int argc, char *argv[]) {
     cmin.setup();
     auto setup_stop = clock::now();
 
-
     auto run_start = clock::now();
     std::complex<double> r = cmin.run();
     auto run_stop = clock::now();
 
     // Check solution
     auto check_start = clock::now();
-    if (std::abs(r - cmin.expect()) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r - cmin.expect()) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Complex Min: result incorrect" << std::endl
-        << "Expected: " << cmin.expect() << std::endl
-        << "Result: " << r << std::endl
-        << "Difference: " << std::abs(r - cmin.expect()) << std::endl
-        << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
+                << "Expected: " << cmin.expect() << std::endl
+                << "Result: " << r << std::endl
+                << "Difference: " << std::abs(r - cmin.expect()) << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon()
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -262,13 +284,10 @@ int main(int argc, char *argv[]) {
     cmin.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Complex Min",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
+    print_timing("Complex Min", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -283,7 +302,6 @@ int main(int argc, char *argv[]) {
     summary.setup();
     auto setup_stop = clock::now();
 
-
     auto run_start = clock::now();
     field_summary::reduction_vars r = summary.run();
     auto run_stop = clock::now();
@@ -293,33 +311,36 @@ int main(int argc, char *argv[]) {
     field_summary::reduction_vars expected = summary.expect();
     if (std::abs(r.vol - expected.vol) > 1.0E-8) {
       std::cerr << "Field Summary: vol result incorrect" << std::endl
-        << "Expected: " << expected.vol << std::endl
-        << "Result: " << r.vol << std::endl
-        << "Difference: " << std::abs(r.vol - expected.vol) << std::endl;
+                << "Expected: " << expected.vol << std::endl
+                << "Result: " << r.vol << std::endl
+                << "Difference: " << std::abs(r.vol - expected.vol)
+                << std::endl;
     }
     if (std::abs(r.mass - expected.mass) > 1.0E-8) {
       std::cerr << "Field Summary: mass result incorrect" << std::endl
-        << "Expected: " << expected.mass << std::endl
-        << "Result: " << r.mass << std::endl
-        << "Difference: " << std::abs(r.mass - expected.mass) << std::endl;
+                << "Expected: " << expected.mass << std::endl
+                << "Result: " << r.mass << std::endl
+                << "Difference: " << std::abs(r.mass - expected.mass)
+                << std::endl;
     }
     if (std::abs(r.ie - expected.ie) > 1.0E-8) {
       std::cerr << "Field Summary: ie result incorrect" << std::endl
-        << "Expected: " << expected.ie << std::endl
-        << "Result: " << r.ie << std::endl
-        << "Difference: " << std::abs(r.ie - expected.ie) << std::endl;
+                << "Expected: " << expected.ie << std::endl
+                << "Result: " << r.ie << std::endl
+                << "Difference: " << std::abs(r.ie - expected.ie) << std::endl;
     }
     if (std::abs(r.ke - expected.ke) > 1.0E-8) {
       std::cerr << "Field Summary: ke result incorrect" << std::endl
-        << "Expected: " << expected.ke << std::endl
-        << "Result: " << r.ke << std::endl
-        << "Difference: " << std::abs(r.ke - expected.ke) << std::endl;
+                << "Expected: " << expected.ke << std::endl
+                << "Result: " << r.ke << std::endl
+                << "Difference: " << std::abs(r.ke - expected.ke) << std::endl;
     }
     if (std::abs(r.press - expected.press) > 1.0E-8) {
       std::cerr << "Field Summary: press result incorrect" << std::endl
-        << "Expected: " << expected.press << std::endl
-        << "Result: " << r.press << std::endl
-        << "Difference: " << std::abs(r.press - expected.press) << std::endl;
+                << "Expected: " << expected.press << std::endl
+                << "Result: " << r.press << std::endl
+                << "Difference: " << std::abs(r.press - expected.press)
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -327,13 +348,10 @@ int main(int argc, char *argv[]) {
     summary.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Field Summary",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
+    print_timing("Field Summary", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
 
   }
 
@@ -352,7 +370,6 @@ int main(int argc, char *argv[]) {
     d.setup();
     auto setup_stop = clock::now();
 
-
     auto run_start = clock::now();
     describe::result r = d.run();
     auto run_stop = clock::now();
@@ -360,39 +377,47 @@ int main(int argc, char *argv[]) {
     // Check solution
     auto check_start = clock::now();
     describe::result expected = d.expect();
-    if (std::abs(r.count - expected.count) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r.count - expected.count) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: count result incorrect" << std::endl
-        << "Expected: " << expected.count << std::endl
-        << "Result: " << r.count << std::endl
-        << "Difference: " << std::abs(r.count - expected.count) << std::endl;
+                << "Expected: " << expected.count << std::endl
+                << "Result: " << r.count << std::endl
+                << "Difference: " << std::abs(r.count - expected.count)
+                << std::endl;
     }
-    // Check this one to E-12 as computed analytically rather than large sum, and FP
-    // errors seem to accumulate
+    // Check this one to E-12 as computed analytically rather than large sum,
+    // and FP errors seem to accumulate
     if (std::abs(r.mean - expected.mean) > 1.0E-12) {
       std::cerr << "Describe: mean result incorrect" << std::endl
-        << "Expected: " << expected.mean << std::endl
-        << "Result: " << r.mean << std::endl
-        << "Difference: " << std::abs(r.mean - expected.mean) << std::endl;
+                << "Expected: " << expected.mean << std::endl
+                << "Result: " << r.mean << std::endl
+                << "Difference: " << std::abs(r.mean - expected.mean)
+                << std::endl;
     }
     // The Sqrt operation drastically increases the error, so check to 4 d.p
     // This is equiv to checking the variance with a tolerance of 1.E-8
     if (std::abs(r.std - expected.std) > 1.0E-4) {
       std::cerr << "Describe: std result incorrect" << std::endl
-        << "Expected: " << std::fixed << expected.std << std::endl
-        << "Result: " << std::fixed << r.std << std::endl
-        << "Difference: " << std::abs(r.std - expected.std) << std::endl;
+                << "Expected: " << std::fixed << expected.std << std::endl
+                << "Result: " << std::fixed << r.std << std::endl
+                << "Difference: " << std::abs(r.std - expected.std)
+                << std::endl;
     }
-    if (std::abs(r.min - expected.min) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r.min - expected.min) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: min result incorrect" << std::endl
-        << "Expected: " << expected.min << std::endl
-        << "Result: " << r.min << std::endl
-        << "Difference: " << std::abs(r.min - expected.min) << std::endl;
+                << "Expected: " << expected.min << std::endl
+                << "Result: " << r.min << std::endl
+                << "Difference: " << std::abs(r.min - expected.min)
+                << std::endl;
     }
-    if (std::abs(r.max - expected.max) > std::numeric_limits<double>::epsilon()*100.0) {
+    if (std::abs(r.max - expected.max) >
+        std::numeric_limits<double>::epsilon() * 100.0) {
       std::cerr << "Describe: max result incorrect" << std::endl
-        << "Expected: " << expected.max << std::endl
-        << "Result: " << r.max << std::endl
-        << "Difference: " << std::abs(r.max - expected.max) << std::endl;
+                << "Expected: " << expected.max << std::endl
+                << "Result: " << r.max << std::endl
+                << "Difference: " << std::abs(r.max - expected.max)
+                << std::endl;
     }
     auto check_stop = clock::now();
 
@@ -400,16 +425,11 @@ int main(int argc, char *argv[]) {
     d.teardown();
     auto teardown_stop = clock::now();
 
-    print_timing("Describe",
-      elapsed(construct_start, construct_stop),
-      elapsed(setup_start, setup_stop),
-      elapsed(run_start, run_stop),
-      elapsed(check_start, check_stop),
-      elapsed(teardown_start, teardown_stop)
-    );
-
+    print_timing("Describe", elapsed(construct_start, construct_stop),
+                 elapsed(setup_start, setup_stop), elapsed(run_start, run_stop),
+                 elapsed(check_start, check_stop),
+                 elapsed(teardown_start, teardown_stop));
   }
 
   return EXIT_SUCCESS;
 }
-

--- a/src/omp-target/complex_min.cpp
+++ b/src/omp-target/complex_min.cpp
@@ -10,45 +10,38 @@
 
 #include "util.hpp"
 
-template <typename T>
-struct complex_min<T>::data {
-  std::complex<T>* C;
-};
+template <typename T> struct complex_min<T>::data { std::complex<T> *C; };
 
 template <typename T>
 complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
 }
 
-template <typename T>
-complex_min<T>::~complex_min() = default;
+template <typename T> complex_min<T>::~complex_min() = default;
 
-template <typename T>
-void complex_min<T>::setup() {
+template <typename T> void complex_min<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
-#pragma omp target enter data map(alloc:C[0:N])
+#pragma omp target enter data map(alloc : C [0:N])
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
-    T v = std::abs(static_cast<T>(N)/2.0 - static_cast<T>(i));
+    T v = std::abs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
     C[i] = std::complex<T>{v, v};
   }
 
-#pragma omp target update to(C[0:N])
-
+#pragma omp target update to(C [0:N])
 }
 
-template <typename T>
-void complex_min<T>::teardown() {
-#pragma omp target exit data map(delete:pdata->C)
+template <typename T> void complex_min<T>::teardown() {
+#pragma omp target exit data map(delete : pdata->C)
 
   delete[] pdata->C;
 }
@@ -60,16 +53,16 @@ std::complex<T> minimum(const std::complex<T> a, const std::complex<T> b) {
 }
 #pragma omp end declare target
 
-template <typename T>
-std::complex<T> complex_min<T>::run() {
+template <typename T> std::complex<T> complex_min<T>::run() {
 #pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
 
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
   auto big = std::numeric_limits<T>::max();
-  std::complex<T> smallest {big, big};
+  std::complex<T> smallest{big, big};
 
-  #pragma omp target teams distribute parallel for reduction(my_complex_min: smallest)
+#pragma omp target teams distribute parallel for reduction(my_complex_min      \
+                                                           : smallest)
   for (long i = 0; i < N; ++i) {
     smallest = minimum(smallest, C[i]);
   }

--- a/src/omp-target/complex_min.cpp
+++ b/src/omp-target/complex_min.cpp
@@ -10,7 +10,10 @@
 
 #include "util.hpp"
 
-template <typename T> struct complex_min<T>::data { std::complex<T> *C; };
+template <typename T>
+struct complex_min<T>::data {
+  std::complex<T> *C;
+};
 
 template <typename T>
 complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -21,9 +24,11 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
   }
 }
 
-template <typename T> complex_min<T>::~complex_min() = default;
+template <typename T>
+complex_min<T>::~complex_min() = default;
 
-template <typename T> void complex_min<T>::setup() {
+template <typename T>
+void complex_min<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
@@ -40,7 +45,8 @@ template <typename T> void complex_min<T>::setup() {
 #pragma omp target update to(C [0:N])
 }
 
-template <typename T> void complex_min<T>::teardown() {
+template <typename T>
+void complex_min<T>::teardown() {
 #pragma omp target exit data map(delete : pdata->C)
 
   delete[] pdata->C;
@@ -53,16 +59,16 @@ std::complex<T> minimum(const std::complex<T> a, const std::complex<T> b) {
 }
 #pragma omp end declare target
 
-template <typename T> std::complex<T> complex_min<T>::run() {
-#pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
+template <typename T>
+std::complex<T> complex_min<T>::run() {
+#pragma omp declare reduction(my_complex_min : std::complex <T> : omp_out = minimum(omp_out, omp_in))
 
   std::complex<T> *C = pdata->C;
 
   auto big = std::numeric_limits<T>::max();
   std::complex<T> smallest{big, big};
 
-#pragma omp target teams distribute parallel for reduction(my_complex_min      \
-                                                           : smallest)
+#pragma omp target teams distribute parallel for reduction(my_complex_min : smallest)
   for (long i = 0; i < N; ++i) {
     smallest = minimum(smallest, C[i]);
   }

--- a/src/omp-target/complex_sum.cpp
+++ b/src/omp-target/complex_sum.cpp
@@ -9,7 +9,10 @@
 
 #include "util.hpp"
 
-template <typename T> struct complex_sum<T>::data { std::complex<T> *C; };
+template <typename T>
+struct complex_sum<T>::data {
+  std::complex<T> *C;
+};
 
 template <typename T>
 complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -20,9 +23,11 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
   }
 }
 
-template <typename T> complex_sum<T>::~complex_sum() = default;
+template <typename T>
+complex_sum<T>::~complex_sum() = default;
 
-template <typename T> void complex_sum<T>::setup() {
+template <typename T>
+void complex_sum<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
@@ -39,19 +44,21 @@ template <typename T> void complex_sum<T>::setup() {
 #pragma omp target update to(C [0:N])
 }
 
-template <typename T> void complex_sum<T>::teardown() {
+template <typename T>
+void complex_sum<T>::teardown() {
 #pragma omp target exit data map(delete : pdata->C)
 
   delete[] pdata->C;
 }
 
-template <typename T> std::complex<T> complex_sum<T>::run() {
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
 
   std::complex<T> *C = pdata->C;
 
   std::complex<T> sum{0.0, 0.0};
 
-#pragma omp declare reduction(my_complex_sum : std::complex<T> : omp_out += omp_in)
+#pragma omp declare reduction(my_complex_sum : std::complex <T> : omp_out += omp_in)
 
 #pragma omp target teams distribute parallel for reduction(my_complex_sum : sum)
   for (long i = 0; i < N; ++i) {

--- a/src/omp-target/complex_sum.cpp
+++ b/src/omp-target/complex_sum.cpp
@@ -9,60 +9,51 @@
 
 #include "util.hpp"
 
-template <typename T>
-struct complex_sum<T>::data {
-  std::complex<T>* C;
-};
+template <typename T> struct complex_sum<T>::data { std::complex<T> *C; };
 
 template <typename T>
 complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
 }
 
-template <typename T>
-complex_sum<T>::~complex_sum() = default;
+template <typename T> complex_sum<T>::~complex_sum() = default;
 
-template <typename T>
-void complex_sum<T>::setup() {
+template <typename T> void complex_sum<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
-#pragma omp target enter data map(alloc:C[0:N])
+#pragma omp target enter data map(alloc : C [0:N])
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
     T v = 2.0 * 1024.0 / static_cast<T>(N);
     C[i] = std::complex<T>{v, v};
   }
 
-#pragma omp target update to(C[0:N])
-
+#pragma omp target update to(C [0:N])
 }
 
-
-template <typename T>
-void complex_sum<T>::teardown() {
-#pragma omp target exit data map(delete:pdata->C)
+template <typename T> void complex_sum<T>::teardown() {
+#pragma omp target exit data map(delete : pdata->C)
 
   delete[] pdata->C;
 }
 
-template <typename T>
-std::complex<T> complex_sum<T>::run() {
+template <typename T> std::complex<T> complex_sum<T>::run() {
 
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
-  std::complex<T> sum {0.0, 0.0};
+  std::complex<T> sum{0.0, 0.0};
 
-  #pragma omp declare reduction(my_complex_sum : std::complex<T> : omp_out += omp_in)
+#pragma omp declare reduction(my_complex_sum : std::complex<T> : omp_out += omp_in)
 
-  #pragma omp target teams distribute parallel for reduction(my_complex_sum:sum)
+#pragma omp target teams distribute parallel for reduction(my_complex_sum : sum)
   for (long i = 0; i < N; ++i) {
     sum += C[i];
   }

--- a/src/omp-target/complex_sum_soa.cpp
+++ b/src/omp-target/complex_sum_soa.cpp
@@ -9,26 +9,24 @@
 
 #include "util.hpp"
 
-template<typename T>
-struct complex_sum_soa<T>::data {
+template <typename T> struct complex_sum_soa<T>::data {
   T *real;
   T *imag;
 };
 
-template<typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
+template <typename T>
+complex_sum_soa<T>::complex_sum_soa(long N_)
+    : N(N_), pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
 }
 
-template<typename T>
-complex_sum_soa<T>::~complex_sum_soa() = default;
+template <typename T> complex_sum_soa<T>::~complex_sum_soa() = default;
 
-template<typename T>
-void complex_sum_soa<T>::setup() {
+template <typename T> void complex_sum_soa<T>::setup() {
 
   pdata->real = new T[N];
   pdata->imag = new T[N];
@@ -36,30 +34,26 @@ void complex_sum_soa<T>::setup() {
   T *real = pdata->real;
   T *imag = pdata->imag;
 
-#pragma omp target enter data map(alloc:real[0:N], imag[0:N])
+#pragma omp target enter data map(alloc : real [0:N], imag [0:N])
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
     T v = 2.0 * 1024.0 / static_cast<T>(N);
     real[i] = v;
     imag[i] = v;
   }
 
-#pragma omp target update to(real[0:N],imag[0:N])
-
+#pragma omp target update to(real [0:N], imag [0:N])
 }
 
-template<typename T>
-void complex_sum_soa<T>::teardown() {
-#pragma omp target exit data map(delete:pdata->real, pdata->imag)
+template <typename T> void complex_sum_soa<T>::teardown() {
+#pragma omp target exit data map(delete : pdata->real, pdata->imag)
 
   delete[] pdata->real;
   delete[] pdata->imag;
 }
 
-
-template<typename T>
-std::tuple<T,T> complex_sum_soa<T>::run() {
+template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
 
   T *real = pdata->real;
   T *imag = pdata->imag;
@@ -67,7 +61,7 @@ std::tuple<T,T> complex_sum_soa<T>::run() {
   T sum_r = 0.0;
   T sum_i = 0.0;
 
-  #pragma omp target teams distribute parallel for reduction(+: sum_r, sum_i)
+#pragma omp target teams distribute parallel for reduction(+ : sum_r, sum_i)
   for (long i = 0; i < N; ++i) {
     sum_r += real[i];
     sum_i += imag[i];

--- a/src/omp-target/complex_sum_soa.cpp
+++ b/src/omp-target/complex_sum_soa.cpp
@@ -9,14 +9,14 @@
 
 #include "util.hpp"
 
-template <typename T> struct complex_sum_soa<T>::data {
+template <typename T>
+struct complex_sum_soa<T>::data {
   T *real;
   T *imag;
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_)
-    : N(N_), pdata{std::make_unique<data>()} {
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
   if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
@@ -24,9 +24,11 @@ complex_sum_soa<T>::complex_sum_soa(long N_)
   }
 }
 
-template <typename T> complex_sum_soa<T>::~complex_sum_soa() = default;
+template <typename T>
+complex_sum_soa<T>::~complex_sum_soa() = default;
 
-template <typename T> void complex_sum_soa<T>::setup() {
+template <typename T>
+void complex_sum_soa<T>::setup() {
 
   pdata->real = new T[N];
   pdata->imag = new T[N];
@@ -46,14 +48,16 @@ template <typename T> void complex_sum_soa<T>::setup() {
 #pragma omp target update to(real [0:N], imag [0:N])
 }
 
-template <typename T> void complex_sum_soa<T>::teardown() {
+template <typename T>
+void complex_sum_soa<T>::teardown() {
 #pragma omp target exit data map(delete : pdata->real, pdata->imag)
 
   delete[] pdata->real;
   delete[] pdata->imag;
 }
 
-template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
+template <typename T>
+std::tuple<T, T> complex_sum_soa<T>::run() {
 
   T *real = pdata->real;
   T *imag = pdata->imag;

--- a/src/omp-target/describe.cpp
+++ b/src/omp-target/describe.cpp
@@ -52,7 +52,7 @@ describe::result describe::run() {
 
   const long count = N;
 
-#pragma omp target teams distribute parallel for reduction(+:mean, lost) reduction(min:min) reduction(max:max)
+#pragma omp target teams distribute parallel for reduction(+ : mean, lost) reduction(min : min) reduction(max : max)
   for (long i = 0; i < N; ++i) {
     // Mean calculation
     double val = D[i] / static_cast<double>(count);
@@ -76,8 +76,7 @@ describe::result describe::run() {
     std += ((D[i] - mean) * (D[i] - mean)) / static_cast<double>(count);
   }
 
-  return {
-      .count = N, .mean = mean, .std = std::sqrt(std), .min = min, .max = max};
+  return {.count = N, .mean = mean, .std = std::sqrt(std), .min = min, .max = max};
 }
 
 void describe::teardown() {

--- a/src/omp-target/describe.cpp
+++ b/src/omp-target/describe.cpp
@@ -16,7 +16,7 @@ struct describe::data {
 
 describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
@@ -27,17 +27,16 @@ describe::~describe() = default;
 void describe::setup() {
   pdata->D = new double[N];
 
-  double * D = pdata->D;
+  double *D = pdata->D;
 
-#pragma omp target enter data map(alloc:D[0:N])
+#pragma omp target enter data map(alloc : D [0:N])
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
-    D[i] = std::abs(static_cast<double>(N)/2.0 - static_cast<double>(i));
+    D[i] = std::abs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
   }
 
-#pragma omp target update to(D[0:N])
-
+#pragma omp target update to(D [0:N])
 }
 
 describe::result describe::run() {
@@ -72,22 +71,17 @@ describe::result describe::run() {
   mean = mean + lost;
   double std = 0.0;
 
-#pragma omp target teams distribute parallel for reduction(+:std)
+#pragma omp target teams distribute parallel for reduction(+ : std)
   for (long i = 0; i < N; ++i) {
     std += ((D[i] - mean) * (D[i] - mean)) / static_cast<double>(count);
   }
 
   return {
-    .count = N,
-    .mean = mean,
-    .std = std::sqrt(std),
-    .min = min,
-    .max = max
-  };
+      .count = N, .mean = mean, .std = std::sqrt(std), .min = min, .max = max};
 }
 
 void describe::teardown() {
-#pragma omp target exit data map(delete:pdata->D)
+#pragma omp target exit data map(delete : pdata->D)
 
   delete[] pdata->D;
 }

--- a/src/omp-target/dot.cpp
+++ b/src/omp-target/dot.cpp
@@ -15,7 +15,7 @@ struct dot::data {
 
 dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
@@ -27,19 +27,18 @@ void dot::setup() {
   pdata->A = new double[N];
   pdata->B = new double[N];
 
-  double * A = pdata->A;
-  double * B = pdata->B;
+  double *A = pdata->A;
+  double *B = pdata->B;
 
-#pragma omp target enter data map(alloc:A[0:N],B[0:N])
+#pragma omp target enter data map(alloc : A [0:N], B [0:N])
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
     A[i] = 1.0 * 1024.0 / static_cast<double>(N);
     B[i] = 2.0 * 1024.0 / static_cast<double>(N);
   }
 
-#pragma omp target update to(A[0:N],B[0:N])
-
+#pragma omp target update to(A [0:N], B [0:N])
 }
 
 double dot::run() {
@@ -49,7 +48,7 @@ double dot::run() {
 
   double sum = 0.0;
 
-#pragma omp target teams distribute parallel for reduction(+:sum)
+#pragma omp target teams distribute parallel for reduction(+ : sum)
   for (long i = 0; i < N; ++i) {
     sum += A[i] * B[i];
   }
@@ -58,7 +57,7 @@ double dot::run() {
 }
 
 void dot::teardown() {
-#pragma omp target exit data map(delete:pdata->A,pdata->B)
+#pragma omp target exit data map(delete : pdata->A, pdata->B)
 
   delete[] pdata->A;
   delete[] pdata->B;

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -20,7 +20,7 @@ struct field_summary::data {
 
 field_summary::field_summary() : pdata{std::make_unique<data>()} {
 
-  if(!is_offloading()) {
+  if (!is_offloading()) {
     std::cerr << "OMP target code is not offloading as expecting" << std::endl;
     exit(1);
   }
@@ -30,15 +30,15 @@ field_summary::~field_summary() = default;
 
 void field_summary::setup() {
   // Allocate arrays
-  pdata->xvel = new double[(nx+1) * (ny+1)];
-  pdata->yvel = new double[(nx+1) * (ny+1)];
+  pdata->xvel = new double[(nx + 1) * (ny + 1)];
+  pdata->yvel = new double[(nx + 1) * (ny + 1)];
   pdata->volume = new double[nx * ny];
   pdata->density = new double[nx * ny];
   pdata->energy = new double[nx * ny];
   pdata->pressure = new double[nx * ny];
 
-  const size_t DOF = nx*ny;
-  const size_t DOF_pad = (nx+1)*(ny+1);
+  const size_t DOF = nx * ny;
+  const size_t DOF_pad = (nx + 1) * (ny + 1);
 
   double *xvel = pdata->xvel;
   double *yvel = pdata->yvel;
@@ -47,53 +47,59 @@ void field_summary::setup() {
   double *energy = pdata->energy;
   double *pressure = pdata->pressure;
 
-#pragma omp target enter data map(alloc:xvel[0:DOF_pad], yvel[0:DOF_pad], \
-  volume[0:DOF], density[0:DOF], energy[0:DOF], pressure[0:DOF])
+#pragma omp target enter data map(alloc                                        \
+                                  : xvel [0:DOF_pad], yvel [0:DOF_pad],        \
+                                    volume [0:DOF], density [0:DOF],           \
+                                    energy [0:DOF], pressure [0:DOF])
 
   // Initalise arrays
-  const double dx = 10.0/static_cast<double>(nx);
-  const double dy = 10.0/static_cast<double>(ny);
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long k = 0; k < ny; ++k) {
-    #pragma omp simd
+#pragma omp simd
     for (long j = 0; j < nx; ++j) {
 
-      volume[j + k*nx] = dx * dy;
-      density[j + k*nx] = 0.2;
-      energy[j + k*nx] = 1.0;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+      volume[j + k * nx] = dx * dy;
+      density[j + k * nx] = 0.2;
+      energy[j + k * nx] = 1.0;
+      pressure[j + k * nx] =
+          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
-  #pragma omp parallel for
-  for (long k = 0; k < ny/5; ++k) {
-    #pragma omp simd
-    for (long j = 0; j < nx/2; ++j) {
+#pragma omp parallel for
+  for (long k = 0; k < ny / 5; ++k) {
+#pragma omp simd
+    for (long j = 0; j < nx / 2; ++j) {
 
-      density[j + k*nx] = 1.0;
-      energy[j + k*nx] = 2.5;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+      density[j + k * nx] = 1.0;
+      energy[j + k * nx] = 2.5;
+      pressure[j + k * nx] =
+          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
-  #pragma omp parallel for
-  for (long k = 0; k < ny+1; ++k) {
-    #pragma omp simd
-    for (long j = 0; j < nx+1; ++j) {
-      xvel[j + k*(nx+1)] = 0.0;
-      yvel[j + k*(nx+1)] = 0.0;
+#pragma omp parallel for
+  for (long k = 0; k < ny + 1; ++k) {
+#pragma omp simd
+    for (long j = 0; j < nx + 1; ++j) {
+      xvel[j + k * (nx + 1)] = 0.0;
+      yvel[j + k * (nx + 1)] = 0.0;
     }
   }
 
-#pragma omp target update to(xvel[0:DOF_pad], yvel[0:DOF_pad], \
-       volume[0:DOF], density[0:DOF], energy[0:DOF], pressure[0:DOF])
-
+#pragma omp target update to(xvel [0:DOF_pad], yvel [0:DOF_pad],               \
+                             volume [0:DOF], density [0:DOF], energy [0:DOF],  \
+                             pressure [0:DOF])
 }
 
 void field_summary::teardown() {
-#pragma omp target exit data map(delete:pdata->xvel, pdata->yvel, \
-  pdata->volume, pdata->density, pdata->energy, pdata->pressure)
+#pragma omp target exit data map(delete                                        \
+                                 : pdata->xvel, pdata->yvel, pdata->volume,    \
+                                   pdata->density, pdata->energy,              \
+                                   pdata->pressure)
 
   delete[] pdata->xvel;
   delete[] pdata->yvel;
@@ -119,23 +125,24 @@ field_summary::reduction_vars field_summary::run() {
   double ke = 0.0;
   double press = 0.0;
 
-  #pragma omp target teams distribute parallel for reduction(+:vol, mass, ie, ke, press)
+#pragma omp target teams distribute parallel for reduction(+:vol, mass, ie, ke, press)
   for (long k = 0; k < ny; ++k) {
-    #pragma omp simd reduction(+:vol, mass, ie, ke, press)
+#pragma omp simd reduction(+ : vol, mass, ie, ke, press)
     for (long j = 0; j < nx; ++j) {
       double vsqrd = 0.0;
-      for (long kv = k; kv <= k+1; ++kv) {
-        for (long jv = j; jv <= j+1; ++jv) {
-          vsqrd += 0.25 * (xvel[jv + kv*(nx+1)] * xvel[jv + kv*(nx+1)] + yvel[jv + kv*(nx+1)] * yvel[jv + kv*(nx+1)]);
+      for (long kv = k; kv <= k + 1; ++kv) {
+        for (long jv = j; jv <= j + 1; ++jv) {
+          vsqrd += 0.25 * (xvel[jv + kv * (nx + 1)] * xvel[jv + kv * (nx + 1)] +
+                           yvel[jv + kv * (nx + 1)] * yvel[jv + kv * (nx + 1)]);
         }
       }
-      double cell_volume = volume[j + k*nx];
-      double cell_mass = cell_volume * density[j + k*nx];
+      double cell_volume = volume[j + k * nx];
+      double cell_mass = cell_volume * density[j + k * nx];
       vol += cell_volume;
       mass += cell_mass;
-      ie += cell_mass * energy[j + k*nx];
+      ie += cell_mass * energy[j + k * nx];
       ke += cell_mass * 0.5 * vsqrd;
-      press += cell_volume * pressure[j + k*nx];
+      press += cell_volume * pressure[j + k * nx];
     }
   }
 

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -47,9 +47,8 @@ void field_summary::setup() {
   double *energy = pdata->energy;
   double *pressure = pdata->pressure;
 
-#pragma omp target enter data map(alloc                                        \
-                                  : xvel [0:DOF_pad], yvel [0:DOF_pad],        \
-                                    volume [0:DOF], density [0:DOF],           \
+#pragma omp target enter data map(alloc                                                                                \
+                                  : xvel [0:DOF_pad], yvel [0:DOF_pad], volume [0:DOF], density [0:DOF],               \
                                     energy [0:DOF], pressure [0:DOF])
 
   // Initalise arrays
@@ -64,8 +63,7 @@ void field_summary::setup() {
       volume[j + k * nx] = dx * dy;
       density[j + k * nx] = 0.2;
       energy[j + k * nx] = 1.0;
-      pressure[j + k * nx] =
-          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      pressure[j + k * nx] = (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
@@ -76,8 +74,7 @@ void field_summary::setup() {
 
       density[j + k * nx] = 1.0;
       energy[j + k * nx] = 2.5;
-      pressure[j + k * nx] =
-          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      pressure[j + k * nx] = (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
@@ -90,15 +87,13 @@ void field_summary::setup() {
     }
   }
 
-#pragma omp target update to(xvel [0:DOF_pad], yvel [0:DOF_pad],               \
-                             volume [0:DOF], density [0:DOF], energy [0:DOF],  \
+#pragma omp target update to(xvel [0:DOF_pad], yvel [0:DOF_pad], volume [0:DOF], density [0:DOF], energy [0:DOF],      \
                              pressure [0:DOF])
 }
 
 void field_summary::teardown() {
-#pragma omp target exit data map(delete                                        \
-                                 : pdata->xvel, pdata->yvel, pdata->volume,    \
-                                   pdata->density, pdata->energy,              \
+#pragma omp target exit data map(delete                                                                                \
+                                 : pdata->xvel, pdata->yvel, pdata->volume, pdata->density, pdata->energy,             \
                                    pdata->pressure)
 
   delete[] pdata->xvel;
@@ -125,7 +120,7 @@ field_summary::reduction_vars field_summary::run() {
   double ke = 0.0;
   double press = 0.0;
 
-#pragma omp target teams distribute parallel for reduction(+:vol, mass, ie, ke, press)
+#pragma omp target teams distribute parallel for reduction(+ : vol, mass, ie, ke, press)
   for (long k = 0; k < ny; ++k) {
 #pragma omp simd reduction(+ : vol, mass, ie, ke, press)
     for (long j = 0; j < nx; ++j) {

--- a/src/omp-target/util.hpp
+++ b/src/omp-target/util.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#pragma < omp.h>
+#include <omp.h>
 
 inline bool is_offloading() {
   int dev;

--- a/src/omp-target/util.hpp
+++ b/src/omp-target/util.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#pragma <omp.h>
+#pragma < omp.h>
 
-inline bool is_offloading()
-{
-    int dev;
-#pragma omp target map(from:dev)
-    {
-        dev = omp_get_device_num();
-    }
-    return dev != omp_get_initial_device();
+inline bool is_offloading() {
+  int dev;
+#pragma omp target map(from : dev)
+  { dev = omp_get_device_num(); }
+  return dev != omp_get_initial_device();
 }

--- a/src/omp/complex_min.cpp
+++ b/src/omp/complex_min.cpp
@@ -8,7 +8,10 @@
 
 #include "../complex_min.hpp"
 
-template <typename T> struct complex_min<T>::data { std::complex<T> *C; };
+template <typename T>
+struct complex_min<T>::data {
+  std::complex<T> *C;
+};
 
 template <typename T>
 complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -20,13 +23,14 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Complex Min is using OpenMP with " << nthreads << " threads."
-            << std::endl;
+  std::cout << "Complex Min is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
-template <typename T> complex_min<T>::~complex_min() = default;
+template <typename T>
+complex_min<T>::~complex_min() = default;
 
-template <typename T> void complex_min<T>::setup() {
+template <typename T>
+void complex_min<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
@@ -39,21 +43,25 @@ template <typename T> void complex_min<T>::setup() {
   }
 }
 
-template <typename T> void complex_min<T>::teardown() { delete[] pdata->C; }
+template <typename T>
+void complex_min<T>::teardown() {
+  delete[] pdata->C;
+}
 
 template <typename T>
 std::complex<T> minimum(const std::complex<T> a, const std::complex<T> b) {
   return std::abs(a) < std::abs(b) ? a : b;
 }
 
-template <typename T> std::complex<T> complex_min<T>::run() {
+template <typename T>
+std::complex<T> complex_min<T>::run() {
 
   std::complex<T> *C = pdata->C;
 
   auto big = std::numeric_limits<T>::max();
   std::complex<T> smallest{big, big};
 
-#pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
+#pragma omp declare reduction(my_complex_min : std::complex <T> : omp_out = minimum(omp_out, omp_in))
 
 #pragma omp parallel for reduction(my_complex_min : smallest)
   for (long i = 0; i < N; ++i) {

--- a/src/omp/complex_min.cpp
+++ b/src/omp/complex_min.cpp
@@ -8,66 +8,54 @@
 
 #include "../complex_min.hpp"
 
-template <typename T>
-struct complex_min<T>::data {
-  std::complex<T>* C;
-};
+template <typename T> struct complex_min<T>::data { std::complex<T> *C; };
 
 template <typename T>
 complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp single
+#pragma omp single
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Complex Min is using OpenMP with "
-    << nthreads << " threads." << std::endl;
-
+  std::cout << "Complex Min is using OpenMP with " << nthreads << " threads."
+            << std::endl;
 }
 
-template <typename T>
-complex_min<T>::~complex_min() = default;
+template <typename T> complex_min<T>::~complex_min() = default;
 
-template <typename T>
-void complex_min<T>::setup() {
+template <typename T> void complex_min<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
-    T v = std::abs(static_cast<T>(N)/2.0 - static_cast<T>(i));
+    T v = std::abs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
     C[i] = std::complex<T>{v, v};
   }
 }
 
-template <typename T>
-void complex_min<T>::teardown() {
-  delete[] pdata->C;
-}
+template <typename T> void complex_min<T>::teardown() { delete[] pdata->C; }
 
 template <typename T>
 std::complex<T> minimum(const std::complex<T> a, const std::complex<T> b) {
   return std::abs(a) < std::abs(b) ? a : b;
 }
 
+template <typename T> std::complex<T> complex_min<T>::run() {
 
-template <typename T>
-std::complex<T> complex_min<T>::run() {
-
-  std::complex<T>* C = pdata->C;
+  std::complex<T> *C = pdata->C;
 
   auto big = std::numeric_limits<T>::max();
-  std::complex<T> smallest {big, big};
+  std::complex<T> smallest{big, big};
 
+#pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
 
-  #pragma omp declare reduction(my_complex_min : std::complex<T> : omp_out = minimum(omp_out,omp_in))
-
-  #pragma omp parallel for reduction(my_complex_min: smallest)
+#pragma omp parallel for reduction(my_complex_min : smallest)
   for (long i = 0; i < N; ++i) {
     smallest = minimum(smallest, C[i]);
   }
@@ -77,4 +65,3 @@ std::complex<T> complex_min<T>::run() {
 
 template struct complex_min<double>;
 template struct complex_min<float>;
-

--- a/src/omp/complex_sum.cpp
+++ b/src/omp/complex_sum.cpp
@@ -7,7 +7,10 @@
 
 #include "../complex_sum.hpp"
 
-template <typename T> struct complex_sum<T>::data { std::complex<T> *C; };
+template <typename T>
+struct complex_sum<T>::data {
+  std::complex<T> *C;
+};
 
 template <typename T>
 complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
@@ -19,13 +22,14 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Complex Sum is using OpenMP with " << nthreads << " threads."
-            << std::endl;
+  std::cout << "Complex Sum is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
-template <typename T> complex_sum<T>::~complex_sum() = default;
+template <typename T>
+complex_sum<T>::~complex_sum() = default;
 
-template <typename T> void complex_sum<T>::setup() {
+template <typename T>
+void complex_sum<T>::setup() {
 
   pdata->C = new std::complex<T>[N];
 
@@ -38,15 +42,19 @@ template <typename T> void complex_sum<T>::setup() {
   }
 }
 
-template <typename T> void complex_sum<T>::teardown() { delete[] pdata->C; }
+template <typename T>
+void complex_sum<T>::teardown() {
+  delete[] pdata->C;
+}
 
-template <typename T> std::complex<T> complex_sum<T>::run() {
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
 
   std::complex<T> *C = pdata->C;
 
   std::complex<T> sum{0.0, 0.0};
 
-#pragma omp declare reduction(my_complex_sum : std::complex<T> : omp_out += omp_in)
+#pragma omp declare reduction(my_complex_sum : std::complex <T> : omp_out += omp_in)
 
 #pragma omp parallel for reduction(my_complex_sum : sum)
   for (long i = 0; i < N; ++i) {

--- a/src/omp/complex_sum_soa.cpp
+++ b/src/omp/complex_sum_soa.cpp
@@ -7,14 +7,14 @@
 
 #include "../complex_sum_soa.hpp"
 
-template <typename T> struct complex_sum_soa<T>::data {
+template <typename T>
+struct complex_sum_soa<T>::data {
   T *real;
   T *imag;
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_)
-    : N(N_), pdata{std::make_unique<data>()} {
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
 #pragma omp parallel
@@ -23,13 +23,14 @@ complex_sum_soa<T>::complex_sum_soa(long N_)
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Complex Sum SoA is using OpenMP with " << nthreads
-            << " threads." << std::endl;
+  std::cout << "Complex Sum SoA is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
-template <typename T> complex_sum_soa<T>::~complex_sum_soa() = default;
+template <typename T>
+complex_sum_soa<T>::~complex_sum_soa() = default;
 
-template <typename T> void complex_sum_soa<T>::setup() {
+template <typename T>
+void complex_sum_soa<T>::setup() {
 
   pdata->real = new T[N];
   pdata->imag = new T[N];
@@ -45,12 +46,14 @@ template <typename T> void complex_sum_soa<T>::setup() {
   }
 }
 
-template <typename T> void complex_sum_soa<T>::teardown() {
+template <typename T>
+void complex_sum_soa<T>::teardown() {
   delete[] pdata->real;
   delete[] pdata->imag;
 }
 
-template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
+template <typename T>
+std::tuple<T, T> complex_sum_soa<T>::run() {
 
   T *real = pdata->real;
   T *imag = pdata->imag;

--- a/src/omp/complex_sum_soa.cpp
+++ b/src/omp/complex_sum_soa.cpp
@@ -7,32 +7,29 @@
 
 #include "../complex_sum_soa.hpp"
 
-template<typename T>
-struct complex_sum_soa<T>::data {
+template <typename T> struct complex_sum_soa<T>::data {
   T *real;
   T *imag;
 };
 
-template<typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
+template <typename T>
+complex_sum_soa<T>::complex_sum_soa(long N_)
+    : N(N_), pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp single
+#pragma omp single
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Complex Sum SoA is using OpenMP with "
-    << nthreads << " threads." << std::endl;
-
+  std::cout << "Complex Sum SoA is using OpenMP with " << nthreads
+            << " threads." << std::endl;
 }
 
-template<typename T>
-complex_sum_soa<T>::~complex_sum_soa() = default;
+template <typename T> complex_sum_soa<T>::~complex_sum_soa() = default;
 
-template<typename T>
-void complex_sum_soa<T>::setup() {
+template <typename T> void complex_sum_soa<T>::setup() {
 
   pdata->real = new T[N];
   pdata->imag = new T[N];
@@ -40,7 +37,7 @@ void complex_sum_soa<T>::setup() {
   T *real = pdata->real;
   T *imag = pdata->imag;
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
     T v = 2.0 * 1024.0 / static_cast<T>(N);
     real[i] = v;
@@ -48,15 +45,12 @@ void complex_sum_soa<T>::setup() {
   }
 }
 
-template<typename T>
-void complex_sum_soa<T>::teardown() {
+template <typename T> void complex_sum_soa<T>::teardown() {
   delete[] pdata->real;
   delete[] pdata->imag;
 }
 
-
-template<typename T>
-std::tuple<T,T> complex_sum_soa<T>::run() {
+template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
 
   T *real = pdata->real;
   T *imag = pdata->imag;
@@ -64,7 +58,7 @@ std::tuple<T,T> complex_sum_soa<T>::run() {
   T sum_r = 0.0;
   T sum_i = 0.0;
 
-  #pragma omp parallel for reduction(+: sum_r, sum_i)
+#pragma omp parallel for reduction(+ : sum_r, sum_i)
   for (long i = 0; i < N; ++i) {
     sum_r += real[i];
     sum_i += imag[i];
@@ -75,4 +69,3 @@ std::tuple<T,T> complex_sum_soa<T>::run() {
 
 template struct complex_sum_soa<double>;
 template struct complex_sum_soa<float>;
-

--- a/src/omp/describe.cpp
+++ b/src/omp/describe.cpp
@@ -15,15 +15,14 @@ struct describe::data {
 describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp single
+#pragma omp single
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Describe is using OpenMP with "
-    << nthreads << " threads." << std::endl;
-
+  std::cout << "Describe is using OpenMP with " << nthreads << " threads."
+            << std::endl;
 }
 
 describe::~describe() = default;
@@ -31,11 +30,11 @@ describe::~describe() = default;
 void describe::setup() {
   pdata->D = new double[N];
 
-  double * D = pdata->D;
+  double *D = pdata->D;
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
-    D[i] = std::abs(static_cast<double>(N)/2.0 - static_cast<double>(i));
+    D[i] = std::abs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
   }
 }
 
@@ -52,7 +51,7 @@ describe::result describe::run() {
   double min = std::numeric_limits<double>::max();
   double max = std::numeric_limits<double>::min();
 
-  #pragma omp parallel for reduction(+:mean, lost) reduction(min:min) reduction(max:max)
+#pragma omp parallel for reduction(+:mean, lost) reduction(min:min) reduction(max:max)
   for (long i = 0; i < N; ++i) {
     // Mean calculation
     double val = D[i] / static_cast<double>(N);
@@ -64,7 +63,6 @@ describe::result describe::run() {
 
     mean += val;
 
-
     min = std::min(min, D[i]);
     max = std::max(max, D[i]);
   }
@@ -73,22 +71,13 @@ describe::result describe::run() {
 
   double std = 0.0;
 
-  #pragma omp parallel for reduction(+:std)
+#pragma omp parallel for reduction(+ : std)
   for (long i = 0; i < N; ++i) {
     std += ((D[i] - mean) * (D[i] - mean)) / static_cast<double>(N);
   }
   std = std::sqrt(std);
 
-  return {
-    .count = count,
-    .mean = mean,
-    .std = std,
-    .min = min,
-    .max = max
-  };
+  return {.count = count, .mean = mean, .std = std, .min = min, .max = max};
 }
 
-void describe::teardown() {
-  delete[] pdata->D;
-}
-
+void describe::teardown() { delete[] pdata->D; }

--- a/src/omp/describe.cpp
+++ b/src/omp/describe.cpp
@@ -21,8 +21,7 @@ describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Describe is using OpenMP with " << nthreads << " threads."
-            << std::endl;
+  std::cout << "Describe is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
 describe::~describe() = default;
@@ -51,7 +50,7 @@ describe::result describe::run() {
   double min = std::numeric_limits<double>::max();
   double max = std::numeric_limits<double>::min();
 
-#pragma omp parallel for reduction(+:mean, lost) reduction(min:min) reduction(max:max)
+#pragma omp parallel for reduction(+ : mean, lost) reduction(min : min) reduction(max : max)
   for (long i = 0; i < N; ++i) {
     // Mean calculation
     double val = D[i] / static_cast<double>(N);

--- a/src/omp/dot.cpp
+++ b/src/omp/dot.cpp
@@ -15,15 +15,14 @@ struct dot::data {
 dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp single
+#pragma omp single
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Dot is using OpenMP with "
-    << nthreads << " threads." << std::endl;
-
+  std::cout << "Dot is using OpenMP with " << nthreads << " threads."
+            << std::endl;
 }
 
 dot::~dot() = default;
@@ -32,10 +31,10 @@ void dot::setup() {
   pdata->A = new double[N];
   pdata->B = new double[N];
 
-  double * A = pdata->A;
-  double * B = pdata->B;
+  double *A = pdata->A;
+  double *B = pdata->B;
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long i = 0; i < N; ++i) {
     A[i] = 1.0 * 1024.0 / static_cast<double>(N);
     B[i] = 2.0 * 1024.0 / static_cast<double>(N);
@@ -49,7 +48,7 @@ double dot::run() {
 
   double sum = 0.0;
 
-  #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
   for (long i = 0; i < N; ++i) {
     sum += A[i] * B[i];
   }
@@ -61,4 +60,3 @@ void dot::teardown() {
   delete[] pdata->A;
   delete[] pdata->B;
 }
-

--- a/src/omp/dot.cpp
+++ b/src/omp/dot.cpp
@@ -21,8 +21,7 @@ dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Dot is using OpenMP with " << nthreads << " threads."
-            << std::endl;
+  std::cout << "Dot is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
 dot::~dot() = default;

--- a/src/omp/field_summary.cpp
+++ b/src/omp/field_summary.cpp
@@ -19,23 +19,22 @@ struct field_summary::data {
 field_summary::field_summary() : pdata{std::make_unique<data>()} {
   int nthreads = 0;
 
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp single
+#pragma omp single
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Field Summary is using OpenMP with "
-    << nthreads << " threads." << std::endl;
-
+  std::cout << "Field Summary is using OpenMP with " << nthreads << " threads."
+            << std::endl;
 }
 
 field_summary::~field_summary() = default;
 
 void field_summary::setup() {
   // Allocate arrays
-  pdata->xvel = new double[(nx+1) * (ny+1)];
-  pdata->yvel = new double[(nx+1) * (ny+1)];
+  pdata->xvel = new double[(nx + 1) * (ny + 1)];
+  pdata->yvel = new double[(nx + 1) * (ny + 1)];
   pdata->volume = new double[nx * ny];
   pdata->density = new double[nx * ny];
   pdata->energy = new double[nx * ny];
@@ -49,41 +48,42 @@ void field_summary::setup() {
   double *pressure = pdata->pressure;
 
   // Initalise arrays
-  const double dx = 10.0/static_cast<double>(nx);
-  const double dy = 10.0/static_cast<double>(ny);
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (long k = 0; k < ny; ++k) {
-    #pragma omp simd
+#pragma omp simd
     for (long j = 0; j < nx; ++j) {
 
-      volume[j + k*nx] = dx * dy;
-      density[j + k*nx] = 0.2;
-      energy[j + k*nx] = 1.0;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+      volume[j + k * nx] = dx * dy;
+      density[j + k * nx] = 0.2;
+      energy[j + k * nx] = 1.0;
+      pressure[j + k * nx] =
+          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
-  #pragma omp parallel for
-  for (long k = 0; k < ny/5; ++k) {
-    #pragma omp simd
-    for (long j = 0; j < nx/2; ++j) {
+#pragma omp parallel for
+  for (long k = 0; k < ny / 5; ++k) {
+#pragma omp simd
+    for (long j = 0; j < nx / 2; ++j) {
 
-      density[j + k*nx] = 1.0;
-      energy[j + k*nx] = 2.5;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
+      density[j + k * nx] = 1.0;
+      energy[j + k * nx] = 2.5;
+      pressure[j + k * nx] =
+          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
-  #pragma omp parallel for
-  for (long k = 0; k < ny+1; ++k) {
-    #pragma omp simd
-    for (long j = 0; j < nx+1; ++j) {
-      xvel[j + k*(nx+1)] = 0.0;
-      yvel[j + k*(nx+1)] = 0.0;
+#pragma omp parallel for
+  for (long k = 0; k < ny + 1; ++k) {
+#pragma omp simd
+    for (long j = 0; j < nx + 1; ++j) {
+      xvel[j + k * (nx + 1)] = 0.0;
+      yvel[j + k * (nx + 1)] = 0.0;
     }
   }
-
 }
 
 void field_summary::teardown() {
@@ -111,27 +111,26 @@ field_summary::reduction_vars field_summary::run() {
   double ke = 0.0;
   double press = 0.0;
 
-  #pragma omp parallel for reduction(+:vol, mass, ie, ke, press)
+#pragma omp parallel for reduction(+ : vol, mass, ie, ke, press)
   for (long k = 0; k < ny; ++k) {
-    #pragma omp simd reduction(+:vol, mass, ie, ke, press)
+#pragma omp simd reduction(+ : vol, mass, ie, ke, press)
     for (long j = 0; j < nx; ++j) {
       double vsqrd = 0.0;
-      for (long kv = k; kv <= k+1; ++kv) {
-        for (long jv = j; jv <= j+1; ++jv) {
-          vsqrd += 0.25 * (xvel[jv + kv*(nx+1)] * xvel[jv + kv*(nx+1)] + yvel[jv + kv*(nx+1)] * yvel[jv + kv*(nx+1)]);
+      for (long kv = k; kv <= k + 1; ++kv) {
+        for (long jv = j; jv <= j + 1; ++jv) {
+          vsqrd += 0.25 * (xvel[jv + kv * (nx + 1)] * xvel[jv + kv * (nx + 1)] +
+                           yvel[jv + kv * (nx + 1)] * yvel[jv + kv * (nx + 1)]);
         }
       }
-      double cell_volume = volume[j + k*nx];
-      double cell_mass = cell_volume * density[j + k*nx];
+      double cell_volume = volume[j + k * nx];
+      double cell_mass = cell_volume * density[j + k * nx];
       vol += cell_volume;
       mass += cell_mass;
-      ie += cell_mass * energy[j + k*nx];
+      ie += cell_mass * energy[j + k * nx];
       ke += cell_mass * 0.5 * vsqrd;
-      press += cell_volume * pressure[j + k*nx];
+      press += cell_volume * pressure[j + k * nx];
     }
   }
 
   return {vol, mass, ie, ke, press};
 }
-
-

--- a/src/omp/field_summary.cpp
+++ b/src/omp/field_summary.cpp
@@ -25,8 +25,7 @@ field_summary::field_summary() : pdata{std::make_unique<data>()} {
     nthreads = omp_get_num_threads();
   }
 
-  std::cout << "Field Summary is using OpenMP with " << nthreads << " threads."
-            << std::endl;
+  std::cout << "Field Summary is using OpenMP with " << nthreads << " threads." << std::endl;
 }
 
 field_summary::~field_summary() = default;
@@ -59,8 +58,7 @@ void field_summary::setup() {
       volume[j + k * nx] = dx * dy;
       density[j + k * nx] = 0.2;
       energy[j + k * nx] = 1.0;
-      pressure[j + k * nx] =
-          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      pressure[j + k * nx] = (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 
@@ -71,8 +69,7 @@ void field_summary::setup() {
 
       density[j + k * nx] = 1.0;
       energy[j + k * nx] = 2.5;
-      pressure[j + k * nx] =
-          (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      pressure[j + k * nx] = (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
     }
   }
 

--- a/src/raja/complex_min.cpp
+++ b/src/raja/complex_min.cpp
@@ -68,7 +68,7 @@ void complex_min<T>::setup() {
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 

--- a/src/raja/complex_min.cpp
+++ b/src/raja/complex_min.cpp
@@ -35,7 +35,6 @@ typedef RAJA::seq_exec policy;
 typedef RAJA::seq_reduce reduce_policy;
 #endif
 
-
 // IMPORTANT NOTE:
 //   This is a hack because I can't get RAJA to build
 //   properly. The documentation and RAJA headers imply
@@ -44,46 +43,41 @@ namespace RAJA {
 using Complex_type = std::complex<double>;
 };
 
-
-template <typename T>
-struct complex_min<T>::data {
+template <typename T> struct complex_min<T>::data {
   // TODO: Use CHAI/Umpire for memory management
   RAJA::Complex_type *C;
 };
 
 template <typename T>
-complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {
-}
+complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {}
 
-template <typename T>
-complex_min<T>::~complex_min() = default;
+template <typename T> complex_min<T>::~complex_min() = default;
 
-template <typename T>
-void complex_min<T>::setup() {
+template <typename T> void complex_min<T>::setup() {
 
   // Allocate memory according to the backend used
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #elif defined(RAJA_ENABLE_HIP)
   hipErrchk(hipMalloc((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #else
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
-
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
-    C[i] = {v, v};
-  });
+  RAJA::forall<policy>(
+      RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
+        RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
+        C[i] = {v, v};
+      });
 }
 
-template <typename T>
-void complex_min<T>::teardown() {
+template <typename T> void complex_min<T>::teardown() {
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaFree(pdata->C));
@@ -96,14 +90,10 @@ void complex_min<T>::teardown() {
   // NOTE: All the data has been destroyed!
 }
 
-
-template <typename T>
-std::complex<T> complex_min<T>::run() {
+template <typename T> std::complex<T> complex_min<T>::run() {
 
   std::cerr << "UNIMPLEMENTED" << std::endl;
   return {-1.0, -1.0};
-
 }
 
 template struct complex_min<RAJA::Real_type>;
-

--- a/src/raja/complex_min.cpp
+++ b/src/raja/complex_min.cpp
@@ -43,7 +43,8 @@ namespace RAJA {
 using Complex_type = std::complex<double>;
 };
 
-template <typename T> struct complex_min<T>::data {
+template <typename T>
+struct complex_min<T>::data {
   // TODO: Use CHAI/Umpire for memory management
   RAJA::Complex_type *C;
 };
@@ -51,15 +52,16 @@ template <typename T> struct complex_min<T>::data {
 template <typename T>
 complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>()} {}
 
-template <typename T> complex_min<T>::~complex_min() = default;
+template <typename T>
+complex_min<T>::~complex_min() = default;
 
-template <typename T> void complex_min<T>::setup() {
+template <typename T>
+void complex_min<T>::setup() {
 
   // Allocate memory according to the backend used
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(
-      cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
+  cudaErrchk(cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #elif defined(RAJA_ENABLE_HIP)
   hipErrchk(hipMalloc((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #else
@@ -70,14 +72,14 @@ template <typename T> void complex_min<T>::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
-  RAJA::forall<policy>(
-      RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-        RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
-        C[i] = {v, v};
-      });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
+    RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
+    C[i] = {v, v};
+  });
 }
 
-template <typename T> void complex_min<T>::teardown() {
+template <typename T>
+void complex_min<T>::teardown() {
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaFree(pdata->C));
@@ -90,7 +92,8 @@ template <typename T> void complex_min<T>::teardown() {
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> std::complex<T> complex_min<T>::run() {
+template <typename T>
+std::complex<T> complex_min<T>::run() {
 
   std::cerr << "UNIMPLEMENTED" << std::endl;
   return {-1.0, -1.0};

--- a/src/raja/complex_min.cpp
+++ b/src/raja/complex_min.cpp
@@ -68,7 +68,7 @@ void complex_min<T>::setup() {
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 

--- a/src/raja/complex_min.cpp
+++ b/src/raja/complex_min.cpp
@@ -72,10 +72,12 @@ void complex_min<T>::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-    RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
-    C[i] = {v, v};
-  });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
+      C[i] = {v, v};
+    });
 }
 
 template <typename T>

--- a/src/raja/complex_sum.cpp
+++ b/src/raja/complex_sum.cpp
@@ -67,7 +67,7 @@ void complex_sum<T>::setup() {
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
@@ -95,7 +95,7 @@ void complex_sum<T>::teardown() {
 
 template <typename T>
 std::complex<T> complex_sum<T>::run() {
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
 
   RAJA::ReduceSum<reduce_policy, RAJA::Complex_type> sum(0.0, 0.0);
 

--- a/src/raja/complex_sum.cpp
+++ b/src/raja/complex_sum.cpp
@@ -71,10 +71,12 @@ void complex_sum<T>::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-    RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
-    C[i] = {v, v};
-  });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
+      C[i] = {v, v};
+    });
 }
 
 template <typename T>
@@ -97,7 +99,11 @@ std::complex<T> complex_sum<T>::run() {
 
   RAJA::ReduceSum<reduce_policy, RAJA::Complex_type> sum(0.0, 0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) { sum += C[i]; });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      sum += C[i];
+    });
 
   return sum.get();
 }

--- a/src/raja/complex_sum.cpp
+++ b/src/raja/complex_sum.cpp
@@ -67,7 +67,7 @@ void complex_sum<T>::setup() {
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
@@ -93,7 +93,7 @@ void complex_sum<T>::teardown() {
 
 template <typename T>
 std::complex<T> complex_sum<T>::run() {
-  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
 
   RAJA::ReduceSum<reduce_policy, RAJA::Complex_type> sum(0.0, 0.0);
 

--- a/src/raja/complex_sum.cpp
+++ b/src/raja/complex_sum.cpp
@@ -34,7 +34,6 @@ typedef RAJA::seq_exec policy;
 typedef RAJA::seq_reduce reduce_policy;
 #endif
 
-
 // IMPORTANT NOTE:
 //   This is a hack because I can't get RAJA to build
 //   properly. The documentation and RAJA headers imply
@@ -43,44 +42,42 @@ namespace RAJA {
 using Complex_type = std::complex<double>;
 };
 
-template <typename T>
-struct complex_sum<T>::data {
+template <typename T> struct complex_sum<T>::data {
   // TODO: Use CHAI/Umpire for memory management
   RAJA::Complex_type *C;
 };
 
 template <typename T>
-complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>()} {
-};
+complex_sum<T>::complex_sum(long N_)
+    : N(N_), pdata{std::make_unique<data>()} {};
 
-template <typename T>
-complex_sum<T>::~complex_sum() = default;
+template <typename T> complex_sum<T>::~complex_sum() = default;
 
-template <typename T>
-void complex_sum<T>::setup() {
+template <typename T> void complex_sum<T>::setup() {
 
   // Allocate memory according to the backend used
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #elif defined(RAJA_ENABLE_HIP)
   hipErrchk(hipMalloc((void **)&(pdata->C), sizeof(RAJA::Complex_type) * N));
 #else
   pdata->C = new RAJA::Complex_type[N];
 #endif
 
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
   // Have to pull this out of the class because the lambda capture falls over
   const RAJA::Real_type n = static_cast<RAJA::Real_type>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
-    C[i] = {v, v};
-  });
+  RAJA::forall<policy>(
+      RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
+        RAJA::Real_type v = 2.0 * 1024.0 / static_cast<RAJA::Real_type>(N);
+        C[i] = {v, v};
+      });
 }
 
-template <typename T>
-void complex_sum<T>::teardown() {
+template <typename T> void complex_sum<T>::teardown() {
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaFree(pdata->C));
@@ -93,18 +90,15 @@ void complex_sum<T>::teardown() {
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T>
-std::complex<T> complex_sum<T>::run() {
-  RAJA::Complex_type * RAJA_RESTRICT C = pdata->C;
+template <typename T> std::complex<T> complex_sum<T>::run() {
+  RAJA::Complex_type *RAJA_RESTRICT C = pdata->C;
 
   RAJA::ReduceSum<reduce_policy, RAJA::Complex_type> sum(0.0, 0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0,N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    sum += C[i];
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) { sum += C[i]; });
 
   return sum.get();
 }
 
 template struct complex_sum<RAJA::Real_type>;
-

--- a/src/raja/complex_sum_soa.cpp
+++ b/src/raja/complex_sum_soa.cpp
@@ -63,8 +63,8 @@ void complex_sum_soa<T>::setup() {
   pdata->imag = new T[N];
 #endif
 
-  T * RAJA_RESTRICT real = pdata->real;
-  T * RAJA_RESTRICT imag = pdata->imag;
+  T *RAJA_RESTRICT real = pdata->real;
+  T *RAJA_RESTRICT imag = pdata->imag;
   // Have to pull this out of the class because the lambda capture falls over
   const T n = static_cast<T>(N);
 
@@ -96,8 +96,8 @@ void complex_sum_soa<T>::teardown() {
 
 template <typename T>
 std::tuple<T, T> complex_sum_soa<T>::run() {
-  T * RAJA_RESTRICT real = pdata->real;
-  T * RAJA_RESTRICT imag = pdata->imag;
+  T *RAJA_RESTRICT real = pdata->real;
+  T *RAJA_RESTRICT imag = pdata->imag;
 
   RAJA::ReduceSum<reduce_policy, T> sum_r(0.0);
   RAJA::ReduceSum<reduce_policy, T> sum_i(0.0);

--- a/src/raja/complex_sum_soa.cpp
+++ b/src/raja/complex_sum_soa.cpp
@@ -63,8 +63,8 @@ void complex_sum_soa<T>::setup() {
   pdata->imag = new T[N];
 #endif
 
-  T *RAJA_RESTRICT real = pdata->real;
-  T *RAJA_RESTRICT imag = pdata->imag;
+  T * RAJA_RESTRICT real = pdata->real;
+  T * RAJA_RESTRICT imag = pdata->imag;
   // Have to pull this out of the class because the lambda capture falls over
   const T n = static_cast<T>(N);
 
@@ -94,8 +94,8 @@ void complex_sum_soa<T>::teardown() {
 
 template <typename T>
 std::tuple<T, T> complex_sum_soa<T>::run() {
-  T *RAJA_RESTRICT real = pdata->real;
-  T *RAJA_RESTRICT imag = pdata->imag;
+  T * RAJA_RESTRICT real = pdata->real;
+  T * RAJA_RESTRICT imag = pdata->imag;
 
   RAJA::ReduceSum<reduce_policy, T> sum_r(0.0);
   RAJA::ReduceSum<reduce_policy, T> sum_i(0.0);

--- a/src/raja/complex_sum_soa.cpp
+++ b/src/raja/complex_sum_soa.cpp
@@ -34,22 +34,19 @@ typedef RAJA::seq_exec policy;
 typedef RAJA::seq_reduce reduce_policy;
 #endif
 
-template <typename T>
-struct complex_sum_soa<T>::data {
+template <typename T> struct complex_sum_soa<T>::data {
   // TODO: Use CHAI/Umpire for memory management
   T *real;
   T *imag;
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>()} {
-};
+complex_sum_soa<T>::complex_sum_soa(long N_)
+    : N(N_), pdata{std::make_unique<data>()} {};
 
-template <typename T>
-complex_sum_soa<T>::~complex_sum_soa() = default;
+template <typename T> complex_sum_soa<T>::~complex_sum_soa() = default;
 
-template <typename T>
-void complex_sum_soa<T>::setup() {
+template <typename T> void complex_sum_soa<T>::setup() {
 
   // Allocate memory according to the backend used
   // TODO: Use CHAI/Umpire for memory management
@@ -64,20 +61,20 @@ void complex_sum_soa<T>::setup() {
   pdata->imag = new T[N];
 #endif
 
-  T * RAJA_RESTRICT real = pdata->real;
-  T * RAJA_RESTRICT imag = pdata->imag;
+  T *RAJA_RESTRICT real = pdata->real;
+  T *RAJA_RESTRICT imag = pdata->imag;
   // Have to pull this out of the class because the lambda capture falls over
   const T n = static_cast<T>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    T v = 2.0 * 1024.0 / static_cast<T>(N);
-    real[i] = v;
-    imag[i] = v;
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         T v = 2.0 * 1024.0 / static_cast<T>(N);
+                         real[i] = v;
+                         imag[i] = v;
+                       });
 }
 
-template <typename T>
-void complex_sum_soa<T>::teardown() {
+template <typename T> void complex_sum_soa<T>::teardown() {
   // TODO: Use CHAI/Umpire for memory management
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaFree(pdata->real));
@@ -93,22 +90,21 @@ void complex_sum_soa<T>::teardown() {
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T>
-std::tuple<T,T> complex_sum_soa<T>::run() {
-  T * RAJA_RESTRICT real = pdata->real;
-  T * RAJA_RESTRICT imag = pdata->imag;
+template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
+  T *RAJA_RESTRICT real = pdata->real;
+  T *RAJA_RESTRICT imag = pdata->imag;
 
   RAJA::ReduceSum<reduce_policy, T> sum_r(0.0);
   RAJA::ReduceSum<reduce_policy, T> sum_i(0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0,N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    sum_r += real[i];
-    sum_i += imag[i];
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         sum_r += real[i];
+                         sum_i += imag[i];
+                       });
 
   return {sum_r.get(), sum_i.get()};
 }
 
 template struct complex_sum_soa<double>;
 template struct complex_sum_soa<float>;
-

--- a/src/raja/complex_sum_soa.cpp
+++ b/src/raja/complex_sum_soa.cpp
@@ -68,11 +68,13 @@ void complex_sum_soa<T>::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const T n = static_cast<T>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-    T v = 2.0 * 1024.0 / static_cast<T>(N);
-    real[i] = v;
-    imag[i] = v;
-  });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      T v = 2.0 * 1024.0 / static_cast<T>(N);
+      real[i] = v;
+      imag[i] = v;
+    });
 }
 
 template <typename T>
@@ -100,10 +102,12 @@ std::tuple<T, T> complex_sum_soa<T>::run() {
   RAJA::ReduceSum<reduce_policy, T> sum_r(0.0);
   RAJA::ReduceSum<reduce_policy, T> sum_i(0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-    sum_r += real[i];
-    sum_i += imag[i];
-  });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      sum_r += real[i];
+      sum_i += imag[i];
+    });
 
   return {sum_r.get(), sum_i.get()};
 }

--- a/src/raja/describe.cpp
+++ b/src/raja/describe.cpp
@@ -56,7 +56,7 @@ void describe::setup() {
   pdata->D = new double[N];
 #endif
 
-  double * RAJA_RESTRICT D = pdata->D;
+  double *RAJA_RESTRICT D = pdata->D;
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
 
@@ -82,7 +82,7 @@ void describe::teardown() {
 
 describe::result describe::run() {
 
-  double * RAJA_RESTRICT D = pdata->D;
+  double *RAJA_RESTRICT D = pdata->D;
 
   long count = N;
 

--- a/src/raja/describe.cpp
+++ b/src/raja/describe.cpp
@@ -56,7 +56,7 @@ void describe::setup() {
   pdata->D = new double[N];
 #endif
 
-  double *RAJA_RESTRICT D = pdata->D;
+  double * RAJA_RESTRICT D = pdata->D;
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
 
@@ -79,7 +79,7 @@ void describe::teardown() {
 
 describe::result describe::run() {
 
-  double *RAJA_RESTRICT D = pdata->D;
+  double * RAJA_RESTRICT D = pdata->D;
 
   long count = N;
 

--- a/src/raja/describe.cpp
+++ b/src/raja/describe.cpp
@@ -37,11 +37,10 @@ typedef RAJA::seq_reduce reduce_policy;
 
 struct describe::data {
   // TODO: Use CHAI/Umpire for memory management
-  double * D;
+  double *D;
 };
 
-describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {
-}
+describe::describe(long N_) : N(N_), pdata{std::make_unique<data>()} {}
 
 describe::~describe() = default;
 
@@ -57,14 +56,14 @@ void describe::setup() {
   pdata->D = new double[N];
 #endif
 
-  double * RAJA_RESTRICT D = pdata->D;
+  double *RAJA_RESTRICT D = pdata->D;
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-
-    D[i] = fabs(N/2.0 - static_cast<double>(i));
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         D[i] = fabs(N / 2.0 - static_cast<double>(i));
+                       });
 }
 
 void describe::teardown() {
@@ -82,51 +81,51 @@ void describe::teardown() {
 
 describe::result describe::run() {
 
-  double * RAJA_RESTRICT D = pdata->D;
+  double *RAJA_RESTRICT D = pdata->D;
 
   long count = N;
 
   const double N = static_cast<double>(N);
 
   // Calculate mean using Kahan summation algorithm, improved by Neumaier
-  RAJA::ReduceSum<reduce_policy, double> mean (0.0);
-  RAJA::ReduceSum<reduce_policy, double> lost (0.0);
+  RAJA::ReduceSum<reduce_policy, double> mean(0.0);
+  RAJA::ReduceSum<reduce_policy, double> lost(0.0);
 
-  RAJA::ReduceMin<reduce_policy, double> min (std::numeric_limits<double>::max());
-  RAJA::ReduceMax<reduce_policy, double> max (std::numeric_limits<double>::min());
+  RAJA::ReduceMin<reduce_policy, double> min(
+      std::numeric_limits<double>::max());
+  RAJA::ReduceMax<reduce_policy, double> max(
+      std::numeric_limits<double>::min());
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0,N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    // Mean calculation
-    double val = D[i] / N;
-    double t = mean + val;
-    if (fabs(mean) >= val)
-      lost += (mean - t) + val;
-    else
-      lost += (val - t) + mean;
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         // Mean calculation
+                         double val = D[i] / N;
+                         double t = mean + val;
+                         if (fabs(mean) >= val)
+                           lost += (mean - t) + val;
+                         else
+                           lost += (val - t) + mean;
 
-    mean += val;
+                         mean += val;
 
+                         min.min(D[i]);
+                         max.max(D[i]);
+                       });
 
-    min.min(D[i]);
-    max.max(D[i]);
-  });
+  double the_mean = mean.get() + lost.get();
 
-  double the_mean = mean.get()+ lost.get();
+  RAJA::ReduceSum<reduce_policy, double> std(0.0);
 
-  RAJA::ReduceSum<reduce_policy, double> std (0.0);
-
-  RAJA::forall<policy>(RAJA::RangeSegment(0,N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    std += ((D[i] - the_mean) * (D[i] - the_mean)) / N;
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         std += ((D[i] - the_mean) * (D[i] - the_mean)) / N;
+                       });
 
   double the_std = std::sqrt(std);
 
-  return {
-    .count = count,
-    .mean = the_mean,
-    .std = the_std,
-    .min = min.get(),
-    .max = max.get()
-  };
+  return {.count = count,
+          .mean = the_mean,
+          .std = the_std,
+          .min = min.get(),
+          .max = max.get()};
 }
-

--- a/src/raja/describe.cpp
+++ b/src/raja/describe.cpp
@@ -61,9 +61,7 @@ void describe::setup() {
   const double N = static_cast<double>(N);
 
   RAJA::forall<policy>(RAJA::RangeSegment(0, N),
-                       [=] RAJA_DEVICE(RAJA::Index_type i) {
-                         D[i] = fabs(N / 2.0 - static_cast<double>(i));
-                       });
+                       [=] RAJA_DEVICE(RAJA::Index_type i) { D[i] = fabs(N / 2.0 - static_cast<double>(i)); });
 }
 
 void describe::teardown() {
@@ -91,41 +89,32 @@ describe::result describe::run() {
   RAJA::ReduceSum<reduce_policy, double> mean(0.0);
   RAJA::ReduceSum<reduce_policy, double> lost(0.0);
 
-  RAJA::ReduceMin<reduce_policy, double> min(
-      std::numeric_limits<double>::max());
-  RAJA::ReduceMax<reduce_policy, double> max(
-      std::numeric_limits<double>::min());
+  RAJA::ReduceMin<reduce_policy, double> min(std::numeric_limits<double>::max());
+  RAJA::ReduceMax<reduce_policy, double> max(std::numeric_limits<double>::min());
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
-                       [=] RAJA_DEVICE(RAJA::Index_type i) {
-                         // Mean calculation
-                         double val = D[i] / N;
-                         double t = mean + val;
-                         if (fabs(mean) >= val)
-                           lost += (mean - t) + val;
-                         else
-                           lost += (val - t) + mean;
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
+    // Mean calculation
+    double val = D[i] / N;
+    double t = mean + val;
+    if (fabs(mean) >= val)
+      lost += (mean - t) + val;
+    else
+      lost += (val - t) + mean;
 
-                         mean += val;
+    mean += val;
 
-                         min.min(D[i]);
-                         max.max(D[i]);
-                       });
+    min.min(D[i]);
+    max.max(D[i]);
+  });
 
   double the_mean = mean.get() + lost.get();
 
   RAJA::ReduceSum<reduce_policy, double> std(0.0);
 
   RAJA::forall<policy>(RAJA::RangeSegment(0, N),
-                       [=] RAJA_DEVICE(RAJA::Index_type i) {
-                         std += ((D[i] - the_mean) * (D[i] - the_mean)) / N;
-                       });
+                       [=] RAJA_DEVICE(RAJA::Index_type i) { std += ((D[i] - the_mean) * (D[i] - the_mean)) / N; });
 
   double the_std = std::sqrt(std);
 
-  return {.count = count,
-          .mean = the_mean,
-          .std = the_std,
-          .min = min.get(),
-          .max = max.get()};
+  return {.count = count, .mean = the_mean, .std = the_std, .min = min.get(), .max = max.get()};
 }

--- a/src/raja/dot.cpp
+++ b/src/raja/dot.cpp
@@ -59,8 +59,8 @@ void dot::setup() {
   pdata->B = new double[N];
 #endif
 
-  double *RAJA_RESTRICT A = pdata->A;
-  double *RAJA_RESTRICT B = pdata->B;
+  double * RAJA_RESTRICT A = pdata->A;
+  double * RAJA_RESTRICT B = pdata->B;
   // Have to pull this out of the class because the lambda capture falls over
   const double n = static_cast<double>(N);
 

--- a/src/raja/dot.cpp
+++ b/src/raja/dot.cpp
@@ -59,8 +59,8 @@ void dot::setup() {
   pdata->B = new double[N];
 #endif
 
-  double * RAJA_RESTRICT A = pdata->A;
-  double * RAJA_RESTRICT B = pdata->B;
+  double *RAJA_RESTRICT A = pdata->A;
+  double *RAJA_RESTRICT B = pdata->B;
   // Have to pull this out of the class because the lambda capture falls over
   const double n = static_cast<double>(N);
 

--- a/src/raja/dot.cpp
+++ b/src/raja/dot.cpp
@@ -40,9 +40,7 @@ struct dot::data {
   double *B;
 };
 
-
-dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {
-};
+dot::dot(long N_) : N(N_), pdata{std::make_unique<data>()} {};
 
 dot::~dot() = default;
 
@@ -61,15 +59,16 @@ void dot::setup() {
   pdata->B = new double[N];
 #endif
 
-  double * RAJA_RESTRICT A = pdata->A;
-  double * RAJA_RESTRICT B = pdata->B;
+  double *RAJA_RESTRICT A = pdata->A;
+  double *RAJA_RESTRICT B = pdata->B;
   // Have to pull this out of the class because the lambda capture falls over
   const double n = static_cast<double>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    A[i] = 1.0 * 1024.0 / n;
-    B[i] = 2.0 * 1024.0 / n;
-  });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
+                       [=] RAJA_DEVICE(RAJA::Index_type i) {
+                         A[i] = 1.0 * 1024.0 / n;
+                         B[i] = 2.0 * 1024.0 / n;
+                       });
 }
 
 void dot::teardown() {
@@ -89,16 +88,14 @@ void dot::teardown() {
 }
 
 double dot::run() {
-  double * A = pdata->A;
-  double * B = pdata->B;
+  double *A = pdata->A;
+  double *B = pdata->B;
 
   RAJA::ReduceSum<reduce_policy, double> sum(0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0,N), [=] RAJA_DEVICE (RAJA::Index_type i) {
-    sum += A[i] * B[i];
-  });
+  RAJA::forall<policy>(
+      RAJA::RangeSegment(0, N),
+      [=] RAJA_DEVICE(RAJA::Index_type i) { sum += A[i] * B[i]; });
 
   return sum.get();
 }
-
-

--- a/src/raja/dot.cpp
+++ b/src/raja/dot.cpp
@@ -64,10 +64,12 @@ void dot::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const double n = static_cast<double>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
-    A[i] = 1.0 * 1024.0 / n;
-    B[i] = 2.0 * 1024.0 / n;
-  });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      A[i] = 1.0 * 1024.0 / n;
+      B[i] = 2.0 * 1024.0 / n;
+    });
 }
 
 void dot::teardown() {
@@ -92,7 +94,11 @@ double dot::run() {
 
   RAJA::ReduceSum<reduce_policy, double> sum(0.0);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) { sum += A[i] * B[i]; });
+  RAJA::forall<policy>(
+    RAJA::RangeSegment(0, N),
+    [=] RAJA_DEVICE(RAJA::Index_type i) {
+      sum += A[i] * B[i];
+    });
 
   return sum.get();
 }

--- a/src/raja/dot.cpp
+++ b/src/raja/dot.cpp
@@ -64,11 +64,10 @@ void dot::setup() {
   // Have to pull this out of the class because the lambda capture falls over
   const double n = static_cast<double>(N);
 
-  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
-                       [=] RAJA_DEVICE(RAJA::Index_type i) {
-                         A[i] = 1.0 * 1024.0 / n;
-                         B[i] = 2.0 * 1024.0 / n;
-                       });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
+    A[i] = 1.0 * 1024.0 / n;
+    B[i] = 2.0 * 1024.0 / n;
+  });
 }
 
 void dot::teardown() {
@@ -93,9 +92,7 @@ double dot::run() {
 
   RAJA::ReduceSum<reduce_policy, double> sum(0.0);
 
-  RAJA::forall<policy>(
-      RAJA::RangeSegment(0, N),
-      [=] RAJA_DEVICE(RAJA::Index_type i) { sum += A[i] * B[i]; });
+  RAJA::forall<policy>(RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) { sum += A[i] * B[i]; });
 
   return sum.get();
 }

--- a/src/raja/field_summary.cpp
+++ b/src/raja/field_summary.cpp
@@ -88,12 +88,12 @@ void field_summary::setup() {
   pdata->pressure = new double[nx * ny];
 #endif
 
-  double *RAJA_RESTRICT xvel = pdata->xvel;
-  double *RAJA_RESTRICT yvel = pdata->yvel;
-  double *RAJA_RESTRICT volume = pdata->volume;
-  double *RAJA_RESTRICT density = pdata->density;
-  double *RAJA_RESTRICT energy = pdata->energy;
-  double *RAJA_RESTRICT pressure = pdata->pressure;
+  double * RAJA_RESTRICT xvel = pdata->xvel;
+  double * RAJA_RESTRICT yvel = pdata->yvel;
+  double * RAJA_RESTRICT volume = pdata->volume;
+  double * RAJA_RESTRICT density = pdata->density;
+  double * RAJA_RESTRICT energy = pdata->energy;
+  double * RAJA_RESTRICT pressure = pdata->pressure;
 
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
@@ -154,12 +154,12 @@ void field_summary::teardown() {
 
 field_summary::reduction_vars field_summary::run() {
 
-  double *RAJA_RESTRICT xvel = pdata->xvel;
-  double *RAJA_RESTRICT yvel = pdata->yvel;
-  double *RAJA_RESTRICT volume = pdata->volume;
-  double *RAJA_RESTRICT density = pdata->density;
-  double *RAJA_RESTRICT energy = pdata->energy;
-  double *RAJA_RESTRICT pressure = pdata->pressure;
+  double * RAJA_RESTRICT xvel = pdata->xvel;
+  double * RAJA_RESTRICT yvel = pdata->yvel;
+  double * RAJA_RESTRICT volume = pdata->volume;
+  double * RAJA_RESTRICT density = pdata->density;
+  double * RAJA_RESTRICT energy = pdata->energy;
+  double * RAJA_RESTRICT pressure = pdata->pressure;
 
   // Reduction variables
   RAJA::ReduceSum<reduce_policy, double> vol = 0.0;

--- a/src/raja/field_summary.cpp
+++ b/src/raja/field_summary.cpp
@@ -17,65 +17,39 @@
 #include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 const size_t CUDA_BLOCK_SIZE = 256;
 typedef RAJA::cuda_reduce reduce_policy;
-using exec_pol =
-  RAJA::KernelPolicy<
-    RAJA::CudaKernel<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>,
-                               RAJA::cuda_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<CUDA_BLOCK_SIZE>,
-                                 RAJA::cuda_block_x_loop,
-          RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
+using exec_pol = RAJA::KernelPolicy<RAJA::CudaKernel<RAJA::statement::Tile<
+    1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>, RAJA::cuda_block_y_loop,
+    RAJA::statement::Tile<
+        0, RAJA::tile_fixed<CUDA_BLOCK_SIZE>, RAJA::cuda_block_x_loop,
+        RAJA::statement::For<
+            1, RAJA::cuda_thread_y_loop,
             RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
-              RAJA::statement::Lambda<0>
-            >
-          >
-        >
-      >
-    >
-  >;
+                                 RAJA::statement::Lambda<0>>>>>>>;
 
 #elif defined(RAJA_ENABLE_HIP)
 #include "RAJA/policy/hip/raja_hiperrchk.hpp"
 const int HIP_BLOCK_SIZE = 256;
 typedef RAJA::hip_reduce reduce_policy;
-using exec_pol =
-  RAJA::KernelPolicy<
-    RAJA::HipKernel<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<HIP_BLOCK_SIZE>,
-                               RAJA::hip_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<HIP_BLOCK_SIZE>,
-                                 RAJA::hip_block_x_loop,
-          RAJA::statement::For<1, RAJA::hip_thread_y_loop,
+using exec_pol = RAJA::KernelPolicy<RAJA::HipKernel<RAJA::statement::Tile<
+    1, RAJA::tile_fixed<HIP_BLOCK_SIZE>, RAJA::hip_block_y_loop,
+    RAJA::statement::Tile<
+        0, RAJA::tile_fixed<HIP_BLOCK_SIZE>, RAJA::hip_block_x_loop,
+        RAJA::statement::For<
+            1, RAJA::hip_thread_y_loop,
             RAJA::statement::For<0, RAJA::hip_thread_x_loop,
-              RAJA::statement::Lambda<0>
-            >
-          >
-        >
-      >
-    >
-  >;
+                                 RAJA::statement::Lambda<0>>>>>>>;
 
 #elif defined(RAJA_ENABLE_OPENMP)
 typedef RAJA::omp_reduce reduce_policy;
-using exec_pol =
-  RAJA::KernelPolicy<
-    RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
-      RAJA::statement::For<0, RAJA::loop_exec,
-        RAJA::statement::Lambda<0>
-      >
-    >
-  >;
+using exec_pol = RAJA::KernelPolicy<RAJA::statement::For<
+    1, RAJA::omp_parallel_for_exec,
+    RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0>>>>;
 
 #else
 typedef RAJA::seq_reduce reduce_policy;
-using exec_pol =
-  RAJA::KernelPolicy<
-    RAJA::statement::For<1, RAJA::seq_exec,
-      RAJA::statement::For<0, RAJA::seq_exec,
-        RAJA::statement::Lambda<0>
-      >
-    >
-  >;
+using exec_pol = RAJA::KernelPolicy<RAJA::statement::For<
+    1, RAJA::seq_exec,
+    RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0>>>>;
 #endif
 
 struct field_summary::data {
@@ -88,8 +62,7 @@ struct field_summary::data {
   double *pressure;
 };
 
-field_summary::field_summary() : pdata{std::make_unique<data>()} {
-};
+field_summary::field_summary() : pdata{std::make_unique<data>()} {};
 
 field_summary::~field_summary() = default;
 
@@ -98,67 +71,77 @@ void field_summary::setup() {
   // TODO: Use CHAI/Umpire for memory management
 
 #if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->xvel), sizeof(double)*(nx+1)*(ny+1)));
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->yvel), sizeof(double)*(nx+1)*(ny+1)));
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->volume), sizeof(double)*nx*ny));
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->density), sizeof(double)*nx*ny));
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->energy), sizeof(double)*nx*ny));
-  cudaErrchk(cudaMallocManaged((void **)&(pdata->pressure), sizeof(double)*nx*ny));
+  cudaErrchk(cudaMallocManaged((void **)&(pdata->xvel),
+                               sizeof(double) * (nx + 1) * (ny + 1)));
+  cudaErrchk(cudaMallocManaged((void **)&(pdata->yvel),
+                               sizeof(double) * (nx + 1) * (ny + 1)));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->volume), sizeof(double) * nx * ny));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->density), sizeof(double) * nx * ny));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->energy), sizeof(double) * nx * ny));
+  cudaErrchk(
+      cudaMallocManaged((void **)&(pdata->pressure), sizeof(double) * nx * ny));
 #elif defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipMalloc((void **)&(pdata->xvel), sizeof(double)*(nx+1)*(ny+1)));
-  hipErrchk(hipMalloc((void **)&(pdata->yvel), sizeof(double)*(nx+1)*(ny+1)));
-  hipErrchk(hipMalloc((void **)&(pdata->volume), sizeof(double)*nx*ny));
-  hipErrchk(hipMalloc((void **)&(pdata->density), sizeof(double)*nx*ny));
-  hipErrchk(hipMalloc((void **)&(pdata->energy), sizeof(double)*nx*ny));
-  hipErrchk(hipMalloc((void **)&(pdata->pressure), sizeof(double)*nx*ny));
+  hipErrchk(
+      hipMalloc((void **)&(pdata->xvel), sizeof(double) * (nx + 1) * (ny + 1)));
+  hipErrchk(
+      hipMalloc((void **)&(pdata->yvel), sizeof(double) * (nx + 1) * (ny + 1)));
+  hipErrchk(hipMalloc((void **)&(pdata->volume), sizeof(double) * nx * ny));
+  hipErrchk(hipMalloc((void **)&(pdata->density), sizeof(double) * nx * ny));
+  hipErrchk(hipMalloc((void **)&(pdata->energy), sizeof(double) * nx * ny));
+  hipErrchk(hipMalloc((void **)&(pdata->pressure), sizeof(double) * nx * ny));
 #else
-  pdata->xvel = new double[(nx+1) * (ny+1)];
-  pdata->yvel = new double[(nx+1) * (ny+1)];
+  pdata->xvel = new double[(nx + 1) * (ny + 1)];
+  pdata->yvel = new double[(nx + 1) * (ny + 1)];
   pdata->volume = new double[nx * ny];
   pdata->density = new double[nx * ny];
   pdata->energy = new double[nx * ny];
   pdata->pressure = new double[nx * ny];
 #endif
 
-  double * RAJA_RESTRICT xvel = pdata->xvel;
-  double * RAJA_RESTRICT yvel = pdata->yvel;
-  double * RAJA_RESTRICT volume = pdata->volume;
-  double * RAJA_RESTRICT density = pdata->density;
-  double * RAJA_RESTRICT energy = pdata->energy;
-  double * RAJA_RESTRICT pressure = pdata->pressure;
+  double *RAJA_RESTRICT xvel = pdata->xvel;
+  double *RAJA_RESTRICT yvel = pdata->yvel;
+  double *RAJA_RESTRICT volume = pdata->volume;
+  double *RAJA_RESTRICT density = pdata->density;
+  double *RAJA_RESTRICT energy = pdata->energy;
+  double *RAJA_RESTRICT pressure = pdata->pressure;
 
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
 
   // Initalise arrays
-  const double dx = 10.0/static_cast<double>(nx);
-  const double dy = 10.0/static_cast<double>(ny);
-
-
-  RAJA::kernel<exec_pol>(
-    RAJA::make_tuple(RAJA::RangeSegment(0, nx), RAJA::RangeSegment(0, ny)),
-    [=] RAJA_DEVICE (RAJA::Index_type j, RAJA::Index_type k) {
-      volume[j + k*nx] = dx * dy;
-      density[j + k*nx] = 0.2;
-      energy[j + k*nx] = 1.0;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
-  });
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
 
   RAJA::kernel<exec_pol>(
-    RAJA::make_tuple(RAJA::RangeSegment(0, nx/2), RAJA::RangeSegment(0, ny/5)),
-    [=] RAJA_DEVICE (RAJA::Index_type j, RAJA::Index_type k) {
-      density[j + k*nx] = 1.0;
-      energy[j + k*nx] = 2.5;
-      pressure[j + k*nx] = (1.4-1.0) * density[j + k*nx] * energy[j + k*nx];
-  });
+      RAJA::make_tuple(RAJA::RangeSegment(0, nx), RAJA::RangeSegment(0, ny)),
+      [=] RAJA_DEVICE(RAJA::Index_type j, RAJA::Index_type k) {
+        volume[j + k * nx] = dx * dy;
+        density[j + k * nx] = 0.2;
+        energy[j + k * nx] = 1.0;
+        pressure[j + k * nx] =
+            (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      });
 
   RAJA::kernel<exec_pol>(
-    RAJA::make_tuple(RAJA::RangeSegment(0, nx+1), RAJA::RangeSegment(0, ny+1)),
-    [=] RAJA_DEVICE (RAJA::Index_type j, RAJA::Index_type k) {
-      xvel[j + k*(nx+1)] = 0.0;
-      yvel[j + k*(nx+1)] = 0.0;
-  });
+      RAJA::make_tuple(RAJA::RangeSegment(0, nx / 2),
+                       RAJA::RangeSegment(0, ny / 5)),
+      [=] RAJA_DEVICE(RAJA::Index_type j, RAJA::Index_type k) {
+        density[j + k * nx] = 1.0;
+        energy[j + k * nx] = 2.5;
+        pressure[j + k * nx] =
+            (1.4 - 1.0) * density[j + k * nx] * energy[j + k * nx];
+      });
 
+  RAJA::kernel<exec_pol>(
+      RAJA::make_tuple(RAJA::RangeSegment(0, nx + 1),
+                       RAJA::RangeSegment(0, ny + 1)),
+      [=] RAJA_DEVICE(RAJA::Index_type j, RAJA::Index_type k) {
+        xvel[j + k * (nx + 1)] = 0.0;
+        yvel[j + k * (nx + 1)] = 0.0;
+      });
 }
 
 void field_summary::teardown() {
@@ -191,12 +174,12 @@ void field_summary::teardown() {
 
 field_summary::reduction_vars field_summary::run() {
 
-  double * RAJA_RESTRICT xvel = pdata->xvel;
-  double * RAJA_RESTRICT yvel = pdata->yvel;
-  double * RAJA_RESTRICT volume = pdata->volume;
-  double * RAJA_RESTRICT density = pdata->density;
-  double * RAJA_RESTRICT energy = pdata->energy;
-  double * RAJA_RESTRICT pressure = pdata->pressure;
+  double *RAJA_RESTRICT xvel = pdata->xvel;
+  double *RAJA_RESTRICT yvel = pdata->yvel;
+  double *RAJA_RESTRICT volume = pdata->volume;
+  double *RAJA_RESTRICT density = pdata->density;
+  double *RAJA_RESTRICT energy = pdata->energy;
+  double *RAJA_RESTRICT pressure = pdata->pressure;
 
   // Reduction variables
   RAJA::ReduceSum<reduce_policy, double> vol = 0.0;
@@ -206,25 +189,24 @@ field_summary::reduction_vars field_summary::run() {
   RAJA::ReduceSum<reduce_policy, double> press = 0.0;
 
   RAJA::kernel<exec_pol>(
-    RAJA::make_tuple(RAJA::RangeSegment(0, nx), RAJA::RangeSegment(0, ny)),
-    [=] RAJA_DEVICE (RAJA::Index_type j, RAJA::Index_type k) {
-
-      double vsqrd = 0.0;
-      for (long kv = k; kv <= k+1; ++kv) {
-        for (long jv = j; jv <= j+1; ++jv) {
-          vsqrd += 0.25 * (xvel[jv + kv*(nx+1)] * xvel[jv + kv*(nx+1)] + yvel[jv + kv*(nx+1)] * yvel[jv + kv*(nx+1)]);
+      RAJA::make_tuple(RAJA::RangeSegment(0, nx), RAJA::RangeSegment(0, ny)),
+      [=] RAJA_DEVICE(RAJA::Index_type j, RAJA::Index_type k) {
+        double vsqrd = 0.0;
+        for (long kv = k; kv <= k + 1; ++kv) {
+          for (long jv = j; jv <= j + 1; ++jv) {
+            vsqrd +=
+                0.25 * (xvel[jv + kv * (nx + 1)] * xvel[jv + kv * (nx + 1)] +
+                        yvel[jv + kv * (nx + 1)] * yvel[jv + kv * (nx + 1)]);
+          }
         }
-      }
-      double cell_volume = volume[j + k*nx];
-      double cell_mass = cell_volume * density[j + k*nx];
-      vol += cell_volume;
-      mass += cell_mass;
-      ie += cell_mass * energy[j + k*nx];
-      ke += cell_mass * 0.5 * vsqrd;
-      press += cell_volume * pressure[j + k*nx];
-  });
+        double cell_volume = volume[j + k * nx];
+        double cell_mass = cell_volume * density[j + k * nx];
+        vol += cell_volume;
+        mass += cell_mass;
+        ie += cell_mass * energy[j + k * nx];
+        ke += cell_mass * 0.5 * vsqrd;
+        press += cell_volume * pressure[j + k * nx];
+      });
 
   return {vol.get(), mass.get(), ie.get(), ke.get(), press.get()};
 }
-
-

--- a/src/raja/field_summary.cpp
+++ b/src/raja/field_summary.cpp
@@ -88,12 +88,12 @@ void field_summary::setup() {
   pdata->pressure = new double[nx * ny];
 #endif
 
-  double * RAJA_RESTRICT xvel = pdata->xvel;
-  double * RAJA_RESTRICT yvel = pdata->yvel;
-  double * RAJA_RESTRICT volume = pdata->volume;
-  double * RAJA_RESTRICT density = pdata->density;
-  double * RAJA_RESTRICT energy = pdata->energy;
-  double * RAJA_RESTRICT pressure = pdata->pressure;
+  double *RAJA_RESTRICT xvel = pdata->xvel;
+  double *RAJA_RESTRICT yvel = pdata->yvel;
+  double *RAJA_RESTRICT volume = pdata->volume;
+  double *RAJA_RESTRICT density = pdata->density;
+  double *RAJA_RESTRICT energy = pdata->energy;
+  double *RAJA_RESTRICT pressure = pdata->pressure;
 
   // Have to pull this out of the class because the lambda capture falls over
   const double N = static_cast<double>(N);
@@ -157,12 +157,12 @@ void field_summary::teardown() {
 
 field_summary::reduction_vars field_summary::run() {
 
-  double * RAJA_RESTRICT xvel = pdata->xvel;
-  double * RAJA_RESTRICT yvel = pdata->yvel;
-  double * RAJA_RESTRICT volume = pdata->volume;
-  double * RAJA_RESTRICT density = pdata->density;
-  double * RAJA_RESTRICT energy = pdata->energy;
-  double * RAJA_RESTRICT pressure = pdata->pressure;
+  double *RAJA_RESTRICT xvel = pdata->xvel;
+  double *RAJA_RESTRICT yvel = pdata->yvel;
+  double *RAJA_RESTRICT volume = pdata->volume;
+  double *RAJA_RESTRICT density = pdata->density;
+  double *RAJA_RESTRICT energy = pdata->energy;
+  double *RAJA_RESTRICT pressure = pdata->pressure;
 
   // Reduction variables
   RAJA::ReduceSum<reduce_policy, double> vol = 0.0;

--- a/src/sycl/common.hpp
+++ b/src/sycl/common.hpp
@@ -1,11 +1,10 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <sycl.hpp>
 #include <sstream>
+#include <sycl.hpp>
 
-static inline std::string config_string(std::string name, sycl::queue& q)
-{
+static inline std::string config_string(std::string name, sycl::queue &q) {
   std::stringstream ss("");
   auto dev = q.get_device();
   auto pname = dev.get_platform().get_info<sycl::info::platform::name>();
@@ -17,39 +16,34 @@ static inline std::string config_string(std::string name, sycl::queue& q)
 }
 
 static inline size_t get_wg_size_for_reduction(sycl::device dev,
-                                               size_t bytes_per_wi)
-{
+                                               size_t bytes_per_wi) {
   // The best work-group size depends on implementation details
   // We make the following assumptions, which aren't specific to DPC++:
   // - Bigger work-groups are better
   // - An implementation may reserve 1 element per work-item in shared memory
   // In practice, DPC++ seems to limit itself to 1/2 of this
-  const size_t max_size = dev.get_info<sycl::info::device::max_work_group_size>();
+  const size_t max_size =
+      dev.get_info<sycl::info::device::max_work_group_size>();
   const size_t local_mem = dev.get_info<sycl::info::device::local_mem_size>();
   return std::min(local_mem / bytes_per_wi, max_size) / 2;
 }
 
-static inline size_t round_up(size_t N, size_t multiple)
-{
+static inline size_t round_up(size_t N, size_t multiple) {
   return ((N + multiple - 1) / multiple) * multiple;
 }
 
 template <typename... BufferT>
-static inline sycl::nd_range<1> get_reduction_range(size_t N,
-                                                    sycl::device dev,
-                                                    BufferT... buffers)
-{
+static inline sycl::nd_range<1> get_reduction_range(size_t N, sycl::device dev,
+                                                    BufferT... buffers) {
   size_t bytes_per_wi = (... + sizeof(typename decltype(buffers)::value_type));
   size_t L = get_wg_size_for_reduction(dev, bytes_per_wi);
   size_t G = round_up(N, L);
   return sycl::nd_range<1>{G, L};
 }
 
-template <typename ... BufferT>
-static inline sycl::nd_range<2> get_reduction_range(sycl::range<2> R,
-                                                    sycl::device dev,
-                                                    BufferT... buffers)
-{
+template <typename... BufferT>
+static inline sycl::nd_range<2>
+get_reduction_range(sycl::range<2> R, sycl::device dev, BufferT... buffers) {
   size_t bytes_per_wi = (... + sizeof(typename decltype(buffers)::value_type));
   size_t L = std::sqrt(get_wg_size_for_reduction(dev, bytes_per_wi));
   size_t G0 = round_up(R[0], L);

--- a/src/sycl/complex_min.cpp
+++ b/src/sycl/complex_min.cpp
@@ -9,7 +9,8 @@
 #include "../complex_min.hpp"
 #include "common.hpp"
 
-template <typename T> struct complex_min<T>::data {
+template <typename T>
+struct complex_min<T>::data {
   data(long N) : C(N), result(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<std::complex<T>> C;
@@ -22,9 +23,11 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Min", pdata->q) << std::endl;
 }
 
-template <typename T> complex_min<T>::~complex_min() {}
+template <typename T>
+complex_min<T>::~complex_min() {}
 
-template <typename T> void complex_min<T>::setup() {
+template <typename T>
+void complex_min<T>::setup() {
   pdata->q
       .submit([&](sycl::handler &h) {
         sycl::accessor result(pdata->result, h, sycl::write_only);
@@ -43,29 +46,29 @@ template <typename T> void complex_min<T>::setup() {
       .wait();
 }
 
-template <typename T> void complex_min<T>::teardown() {
+template <typename T>
+void complex_min<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> struct minabs {
+template <typename T>
+struct minabs {
 public:
-  std::complex<T> operator()(const std::complex<T> &lhs,
-                             const std::complex<T> &rhs) const {
+  std::complex<T> operator()(const std::complex<T> &lhs, const std::complex<T> &rhs) const {
     return (abs(lhs) < abs(rhs)) ? lhs : rhs;
   }
 };
 
-template <typename T> std::complex<T> complex_min<T>::run() {
+template <typename T>
+std::complex<T> complex_min<T>::run() {
   // Identity isn't strictly required here, but may improve performance
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::read_only);
-    std::complex<T> identity = {std::numeric_limits<T>::max(),
-                                std::numeric_limits<T>::max()};
+    std::complex<T> identity = {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
     h.parallel_for(
         sycl::range<1>(N),
-        sycl::reduction(pdata->result, h, identity, minabs<T>(),
-                        sycl::property::reduction::initialize_to_identity{}),
+        sycl::reduction(pdata->result, h, identity, minabs<T>(), sycl::property::reduction::initialize_to_identity{}),
         [=](const int i, auto &result) { result.combine(C[i]); });
   });
 

--- a/src/sycl/complex_min.cpp
+++ b/src/sycl/complex_min.cpp
@@ -9,10 +9,8 @@
 #include "../complex_min.hpp"
 #include "common.hpp"
 
-template <typename T>
-struct complex_min<T>::data {
-  data(long N) : C(N), result(1), q(sycl::default_selector{})
-  {}
+template <typename T> struct complex_min<T>::data {
+  data(long N) : C(N), result(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<std::complex<T>> C;
   sycl::buffer<std::complex<T>> result;
@@ -24,54 +22,51 @@ complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Min", pdata->q) << std::endl;
 }
 
-template <typename T>
-complex_min<T>::~complex_min() {}
+template <typename T> complex_min<T>::~complex_min() {}
 
-template <typename T>
-void complex_min<T>::setup() {
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor result(pdata->result, h, sycl::write_only);
-    h.single_task([=]() {
-      result[0] = std::complex<T>(0, 0);
-    });
-  }).wait();
+template <typename T> void complex_min<T>::setup() {
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor result(pdata->result, h, sycl::write_only);
+        h.single_task([=]() { result[0] = std::complex<T>(0, 0); });
+      })
+      .wait();
 
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
-    sycl::accessor C(pdata->C, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      T v = fabs(static_cast<T>(N)/2.0 - static_cast<T>(i));
-      C[i] = std::complex<T>{v, v};
-    });
-  }).wait();
+  pdata->q
+      .submit([&, N = this->N](sycl::handler &h) {
+        sycl::accessor C(pdata->C, h, sycl::write_only);
+        h.parallel_for(N, [=](const int i) {
+          T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
+          C[i] = std::complex<T>{v, v};
+        });
+      })
+      .wait();
 }
 
-template <typename T>
-void complex_min<T>::teardown() {
+template <typename T> void complex_min<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T>
-struct minabs {
+template <typename T> struct minabs {
 public:
-  std::complex<T> operator()(const std::complex<T>& lhs,
-                             const std::complex<T>& rhs) const {
+  std::complex<T> operator()(const std::complex<T> &lhs,
+                             const std::complex<T> &rhs) const {
     return (abs(lhs) < abs(rhs)) ? lhs : rhs;
   }
 };
 
-template <typename T>
-std::complex<T> complex_min<T>::run() {
+template <typename T> std::complex<T> complex_min<T>::run() {
   // Identity isn't strictly required here, but may improve performance
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::read_only);
-    std::complex<T> identity = { std::numeric_limits<T>::max(),
-                                 std::numeric_limits<T>::max() };
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->result, h, identity, minabs<T>(), sycl::property::reduction::initialize_to_identity{}),
-                   [=](const int i, auto& result) {
-      result.combine(C[i]);
-    });
+    std::complex<T> identity = {std::numeric_limits<T>::max(),
+                                std::numeric_limits<T>::max()};
+    h.parallel_for(
+        sycl::range<1>(N),
+        sycl::reduction(pdata->result, h, identity, minabs<T>(),
+                        sycl::property::reduction::initialize_to_identity{}),
+        [=](const int i, auto &result) { result.combine(C[i]); });
   });
 
   return pdata->result.get_host_access()[0];
@@ -79,4 +74,3 @@ std::complex<T> complex_min<T>::run() {
 
 template struct complex_min<double>;
 template struct complex_min<float>;
-

--- a/src/sycl/complex_min.cpp
+++ b/src/sycl/complex_min.cpp
@@ -28,22 +28,20 @@ complex_min<T>::~complex_min() {}
 
 template <typename T>
 void complex_min<T>::setup() {
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor result(pdata->result, h, sycl::write_only);
-        h.single_task([=]() { result[0] = std::complex<T>(0, 0); });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor result(pdata->result, h, sycl::write_only);
+    h.single_task([=]() { result[0] = std::complex<T>(0, 0); });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&, N = this->N](sycl::handler &h) {
-        sycl::accessor C(pdata->C, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) {
-          T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
-          C[i] = std::complex<T>{v, v};
-        });
-      })
-      .wait();
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor C(pdata->C, h, sycl::write_only);
+    h.parallel_for(N, [=](const int i) {
+      T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
+      C[i] = std::complex<T>{v, v};
+    });
+  });
+  pdata->q.wait();
 }
 
 template <typename T>

--- a/src/sycl/complex_min.cpp
+++ b/src/sycl/complex_min.cpp
@@ -36,10 +36,12 @@ void complex_min<T>::setup() {
 
   pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
-      C[i] = std::complex<T>{v, v};
-    });
+    h.parallel_for(
+      N,
+      [=](const int i) {
+        T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
+        C[i] = std::complex<T>{v, v};
+      });
   });
   pdata->q.wait();
 }
@@ -67,7 +69,9 @@ std::complex<T> complex_min<T>::run() {
     h.parallel_for(
         sycl::range<1>(N),
         sycl::reduction(pdata->result, h, identity, minabs<T>(), sycl::property::reduction::initialize_to_identity{}),
-        [=](const int i, auto &result) { result.combine(C[i]); });
+        [=](const int i, auto &result) {
+          result.combine(C[i]);
+        });
   });
 
   return pdata->result.get_host_access()[0];

--- a/src/sycl/complex_sum.cpp
+++ b/src/sycl/complex_sum.cpp
@@ -35,10 +35,12 @@ void complex_sum<T>::setup() {
 
   pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      T v = 2.0 * 1024.0 / static_cast<T>(N);
-      C[i] = std::complex<T>{v, v};
-    });
+    h.parallel_for(
+      N,
+      [=](const int i) {
+        T v = 2.0 * 1024.0 / static_cast<T>(N);
+        C[i] = std::complex<T>{v, v};
+      });
   });
   pdata->q.wait();
 }
@@ -58,7 +60,9 @@ std::complex<T> complex_sum<T>::run() {
     h.parallel_for(
         sycl::range<1>(N),
         sycl::reduction(pdata->sum, h, identity, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
-        [=](const int i, auto &sum) { sum += C[i]; });
+        [=](const int i, auto &sum) {
+          sum += C[i];
+        });
   });
 
   return pdata->sum.get_host_access()[0];

--- a/src/sycl/complex_sum.cpp
+++ b/src/sycl/complex_sum.cpp
@@ -8,7 +8,8 @@
 #include "../complex_sum.hpp"
 #include "common.hpp"
 
-template <typename T> struct complex_sum<T>::data {
+template <typename T>
+struct complex_sum<T>::data {
   data(long N) : C(N), sum(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<std::complex<T>> C;
@@ -21,9 +22,11 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Sum", pdata->q) << std::endl;
 }
 
-template <typename T> complex_sum<T>::~complex_sum() {}
+template <typename T>
+complex_sum<T>::~complex_sum() {}
 
-template <typename T> void complex_sum<T>::setup() {
+template <typename T>
+void complex_sum<T>::setup() {
   pdata->q
       .submit([&](sycl::handler &h) {
         sycl::accessor sum(pdata->sum, h, sycl::write_only);
@@ -42,20 +45,21 @@ template <typename T> void complex_sum<T>::setup() {
       .wait();
 }
 
-template <typename T> void complex_sum<T>::teardown() {
+template <typename T>
+void complex_sum<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> std::complex<T> complex_sum<T>::run() {
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
   // Identity isn't strictly required here, but may improve performance
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::read_only);
     std::complex<T> identity{0, 0};
     h.parallel_for(
         sycl::range<1>(N),
-        sycl::reduction(pdata->sum, h, identity, std::plus<>(),
-                        sycl::property::reduction::initialize_to_identity{}),
+        sycl::reduction(pdata->sum, h, identity, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
         [=](const int i, auto &sum) { sum += C[i]; });
   });
 

--- a/src/sycl/complex_sum.cpp
+++ b/src/sycl/complex_sum.cpp
@@ -27,22 +27,20 @@ complex_sum<T>::~complex_sum() {}
 
 template <typename T>
 void complex_sum<T>::setup() {
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor sum(pdata->sum, h, sycl::write_only);
-        h.single_task([=]() { sum[0] = std::complex<T>(0, 0); });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor sum(pdata->sum, h, sycl::write_only);
+    h.single_task([=]() { sum[0] = std::complex<T>(0, 0); });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&, N = this->N](sycl::handler &h) {
-        sycl::accessor C(pdata->C, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) {
-          T v = 2.0 * 1024.0 / static_cast<T>(N);
-          C[i] = std::complex<T>{v, v};
-        });
-      })
-      .wait();
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor C(pdata->C, h, sycl::write_only);
+    h.parallel_for(N, [=](const int i) {
+      T v = 2.0 * 1024.0 / static_cast<T>(N);
+      C[i] = std::complex<T>{v, v};
+    });
+  });
+  pdata->q.wait();
 }
 
 template <typename T>

--- a/src/sycl/complex_sum.cpp
+++ b/src/sycl/complex_sum.cpp
@@ -8,10 +8,8 @@
 #include "../complex_sum.hpp"
 #include "common.hpp"
 
-template <typename T>
-struct complex_sum<T>::data {
-  data(long N) : C(N), sum(1), q(sycl::default_selector{})
-  {}
+template <typename T> struct complex_sum<T>::data {
+  data(long N) : C(N), sum(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<std::complex<T>> C;
   sycl::buffer<std::complex<T>> sum;
@@ -23,45 +21,42 @@ complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Sum", pdata->q) << std::endl;
 }
 
-template <typename T>
-complex_sum<T>::~complex_sum() {}
+template <typename T> complex_sum<T>::~complex_sum() {}
 
-template <typename T>
-void complex_sum<T>::setup() {
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor sum(pdata->sum, h, sycl::write_only);
-    h.single_task([=]() {
-      sum[0] = std::complex<T>(0, 0);
-    });
-  }).wait();
+template <typename T> void complex_sum<T>::setup() {
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor sum(pdata->sum, h, sycl::write_only);
+        h.single_task([=]() { sum[0] = std::complex<T>(0, 0); });
+      })
+      .wait();
 
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
-    sycl::accessor C(pdata->C, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      T v = 2.0 * 1024.0 / static_cast<T>(N);
-      C[i] = std::complex<T>{v, v};
-    });
-  }).wait();
+  pdata->q
+      .submit([&, N = this->N](sycl::handler &h) {
+        sycl::accessor C(pdata->C, h, sycl::write_only);
+        h.parallel_for(N, [=](const int i) {
+          T v = 2.0 * 1024.0 / static_cast<T>(N);
+          C[i] = std::complex<T>{v, v};
+        });
+      })
+      .wait();
 }
 
-template <typename T>
-void complex_sum<T>::teardown() {
+template <typename T> void complex_sum<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-
-template <typename T>
-std::complex<T> complex_sum<T>::run() {
+template <typename T> std::complex<T> complex_sum<T>::run() {
   // Identity isn't strictly required here, but may improve performance
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor C(pdata->C, h, sycl::read_only);
     std::complex<T> identity{0, 0};
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->sum, h, identity, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
-                   [=](const int i, auto& sum) {
-      sum += C[i];
-    });
+    h.parallel_for(
+        sycl::range<1>(N),
+        sycl::reduction(pdata->sum, h, identity, std::plus<>(),
+                        sycl::property::reduction::initialize_to_identity{}),
+        [=](const int i, auto &sum) { sum += C[i]; });
   });
 
   return pdata->sum.get_host_access()[0];
@@ -69,4 +64,3 @@ std::complex<T> complex_sum<T>::run() {
 
 template struct complex_sum<double>;
 template struct complex_sum<float>;
-

--- a/src/sycl/complex_sum_soa.cpp
+++ b/src/sycl/complex_sum_soa.cpp
@@ -8,9 +8,9 @@
 #include "../complex_sum_soa.hpp"
 #include "common.hpp"
 
-template <typename T> struct complex_sum_soa<T>::data {
-  data(long N)
-      : real(N), imag(N), sum_r(1), sum_i(1), q(sycl::default_selector{}) {}
+template <typename T>
+struct complex_sum_soa<T>::data {
+  data(long N) : real(N), imag(N), sum_r(1), sum_i(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<T> real;
   sycl::buffer<T> imag;
@@ -20,14 +20,15 @@ template <typename T> struct complex_sum_soa<T>::data {
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_)
-    : N(N_), pdata{std::make_unique<data>(N)} {
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Sum SoA", pdata->q) << std::endl;
 }
 
-template <typename T> complex_sum_soa<T>::~complex_sum_soa() {}
+template <typename T>
+complex_sum_soa<T>::~complex_sum_soa() {}
 
-template <typename T> void complex_sum_soa<T>::setup() {
+template <typename T>
+void complex_sum_soa<T>::setup() {
   pdata->q
       .submit([&](sycl::handler &h) {
         sycl::accessor sum_r(pdata->sum_r, h, sycl::write_only);
@@ -52,12 +53,14 @@ template <typename T> void complex_sum_soa<T>::setup() {
       .wait();
 }
 
-template <typename T> void complex_sum_soa<T>::teardown() {
+template <typename T>
+void complex_sum_soa<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
+template <typename T>
+std::tuple<T, T> complex_sum_soa<T>::run() {
 // Intel DPC++ doesn't yet support multiple reductions with sycl::range
 // For now, use a sycl::nd_range as a workaround
 #if defined(__INTEL_LLVM_COMPILER) || defined(__clang__)
@@ -65,8 +68,7 @@ template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
     sycl::accessor real(pdata->real, h, sycl::read_only);
     sycl::accessor imag(pdata->imag, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->sum_r,
-                                       pdata->sum_i),
+    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->sum_r, pdata->sum_i),
                    sycl::reduction(pdata->sum_r, h, std::plus<>(), properties),
                    sycl::reduction(pdata->sum_i, h, std::plus<>(), properties),
                    [=](sycl::nd_item<1> it, auto &sum_r, auto &sum_i) {
@@ -82,8 +84,7 @@ template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
     sycl::accessor real(pdata->real, h, sycl::read_only);
     sycl::accessor imag(pdata->imag, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->sum_r, h, std::plus<>(), properties),
+    h.parallel_for(sycl::range<1>(N), sycl::reduction(pdata->sum_r, h, std::plus<>(), properties),
                    sycl::reduction(pdata->sum_i, h, std::plus<>(), properties),
                    [=](const int i, auto &sum_r, auto &sum_i) {
                      sum_r += real[i];

--- a/src/sycl/complex_sum_soa.cpp
+++ b/src/sycl/complex_sum_soa.cpp
@@ -8,10 +8,9 @@
 #include "../complex_sum_soa.hpp"
 #include "common.hpp"
 
-template <typename T>
-struct complex_sum_soa<T>::data {
-  data(long N) : real(N), imag(N), sum_r(1), sum_i(1), q(sycl::default_selector{})
-  {}
+template <typename T> struct complex_sum_soa<T>::data {
+  data(long N)
+      : real(N), imag(N), sum_r(1), sum_i(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<T> real;
   sycl::buffer<T> imag;
@@ -21,80 +20,80 @@ struct complex_sum_soa<T>::data {
 };
 
 template <typename T>
-complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+complex_sum_soa<T>::complex_sum_soa(long N_)
+    : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Complex Sum SoA", pdata->q) << std::endl;
 }
 
-template <typename T>
-complex_sum_soa<T>::~complex_sum_soa() {}
+template <typename T> complex_sum_soa<T>::~complex_sum_soa() {}
 
-template <typename T>
-void complex_sum_soa<T>::setup() {
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor sum_r(pdata->sum_r, h, sycl::write_only);
-    sycl::accessor sum_i(pdata->sum_i, h, sycl::write_only);
-    h.single_task([=]() {
-      sum_r[0] = 0;
-      sum_i[0] = 0;
-    });
-  }).wait();
+template <typename T> void complex_sum_soa<T>::setup() {
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor sum_r(pdata->sum_r, h, sycl::write_only);
+        sycl::accessor sum_i(pdata->sum_i, h, sycl::write_only);
+        h.single_task([=]() {
+          sum_r[0] = 0;
+          sum_i[0] = 0;
+        });
+      })
+      .wait();
 
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
-    sycl::accessor real(pdata->real, h, sycl::write_only);
-    sycl::accessor imag(pdata->imag, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      T v = 2.0 * 1024.0 / static_cast<T>(N);
-      real[i] = v;
-      imag[i] = v;
-    });
-  }).wait();
+  pdata->q
+      .submit([&, N = this->N](sycl::handler &h) {
+        sycl::accessor real(pdata->real, h, sycl::write_only);
+        sycl::accessor imag(pdata->imag, h, sycl::write_only);
+        h.parallel_for(N, [=](const int i) {
+          T v = 2.0 * 1024.0 / static_cast<T>(N);
+          real[i] = v;
+          imag[i] = v;
+        });
+      })
+      .wait();
 }
 
-template <typename T>
-void complex_sum_soa<T>::teardown() {
+template <typename T> void complex_sum_soa<T>::teardown() {
   pdata.reset();
   // NOTE: All the data has been destroyed!
 }
 
-
-template <typename T>
-std::tuple<T,T> complex_sum_soa<T>::run() {
+template <typename T> std::tuple<T, T> complex_sum_soa<T>::run() {
 // Intel DPC++ doesn't yet support multiple reductions with sycl::range
 // For now, use a sycl::nd_range as a workaround
 #if defined(__INTEL_LLVM_COMPILER) || defined(__clang__)
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor real(pdata->real, h, sycl::read_only);
     sycl::accessor imag(pdata->imag, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->sum_r, pdata->sum_i),
+    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->sum_r,
+                                       pdata->sum_i),
                    sycl::reduction(pdata->sum_r, h, std::plus<>(), properties),
                    sycl::reduction(pdata->sum_i, h, std::plus<>(), properties),
-                   [=](sycl::nd_item<1> it, auto& sum_r, auto& sum_i) {
-      const int i = it.get_global_id(0);
-      if (i < N) {
-        sum_r += real[i];
-        sum_i += imag[i];
-      }
-    });
+                   [=](sycl::nd_item<1> it, auto &sum_r, auto &sum_i) {
+                     const int i = it.get_global_id(0);
+                     if (i < N) {
+                       sum_r += real[i];
+                       sum_i += imag[i];
+                     }
+                   });
   });
 #else
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor real(pdata->real, h, sycl::read_only);
     sycl::accessor imag(pdata->imag, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
     h.parallel_for(sycl::range<1>(N),
                    sycl::reduction(pdata->sum_r, h, std::plus<>(), properties),
                    sycl::reduction(pdata->sum_i, h, std::plus<>(), properties),
-                   [=](const int i, auto& sum_r, auto& sum_i) {
-      sum_r += real[i];
-      sum_i += imag[i];
-    });
+                   [=](const int i, auto &sum_r, auto &sum_i) {
+                     sum_r += real[i];
+                     sum_i += imag[i];
+                   });
   });
 #endif
 
-  return { pdata->sum_r.get_host_access()[0], pdata->sum_i.get_host_access()[0] };
+  return {pdata->sum_r.get_host_access()[0], pdata->sum_i.get_host_access()[0]};
 }
 
 template struct complex_sum_soa<double>;
 template struct complex_sum_soa<float>;
-

--- a/src/sycl/complex_sum_soa.cpp
+++ b/src/sycl/complex_sum_soa.cpp
@@ -29,28 +29,26 @@ complex_sum_soa<T>::~complex_sum_soa() {}
 
 template <typename T>
 void complex_sum_soa<T>::setup() {
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor sum_r(pdata->sum_r, h, sycl::write_only);
-        sycl::accessor sum_i(pdata->sum_i, h, sycl::write_only);
-        h.single_task([=]() {
-          sum_r[0] = 0;
-          sum_i[0] = 0;
-        });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor sum_r(pdata->sum_r, h, sycl::write_only);
+    sycl::accessor sum_i(pdata->sum_i, h, sycl::write_only);
+    h.single_task([=]() {
+      sum_r[0] = 0;
+      sum_i[0] = 0;
+    });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&, N = this->N](sycl::handler &h) {
-        sycl::accessor real(pdata->real, h, sycl::write_only);
-        sycl::accessor imag(pdata->imag, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) {
-          T v = 2.0 * 1024.0 / static_cast<T>(N);
-          real[i] = v;
-          imag[i] = v;
-        });
-      })
-      .wait();
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor real(pdata->real, h, sycl::write_only);
+    sycl::accessor imag(pdata->imag, h, sycl::write_only);
+    h.parallel_for(N, [=](const int i) {
+      T v = 2.0 * 1024.0 / static_cast<T>(N);
+      real[i] = v;
+      imag[i] = v;
+    });
+  });
+  pdata->q.wait();
 }
 
 template <typename T>

--- a/src/sycl/describe.cpp
+++ b/src/sycl/describe.cpp
@@ -27,27 +27,25 @@ describe::describe(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
 describe::~describe(){};
 
 void describe::setup() {
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor mean(pdata->mean, h, sycl::write_only);
-        sycl::accessor std(pdata->std, h, sycl::write_only);
-        sycl::accessor min(pdata->min, h, sycl::write_only);
-        sycl::accessor max(pdata->max, h, sycl::write_only);
-        h.single_task([=]() {
-          mean[0] = 0;
-          std[0] = 0;
-          min[0] = 0;
-          max[0] = 0;
-        });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor mean(pdata->mean, h, sycl::write_only);
+    sycl::accessor std(pdata->std, h, sycl::write_only);
+    sycl::accessor min(pdata->min, h, sycl::write_only);
+    sycl::accessor max(pdata->max, h, sycl::write_only);
+    h.single_task([=]() {
+      mean[0] = 0;
+      std[0] = 0;
+      min[0] = 0;
+      max[0] = 0;
+    });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&, N = this->N](sycl::handler &h) {
-        sycl::accessor D(pdata->D, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) { D[i] = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
-      })
-      .wait();
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor D(pdata->D, h, sycl::write_only);
+    h.parallel_for(N, [=](const int i) { D[i] = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
+  });
+  pdata->q.wait();
 }
 
 void describe::teardown() {

--- a/src/sycl/describe.cpp
+++ b/src/sycl/describe.cpp
@@ -10,8 +10,8 @@
 #include "common.hpp"
 
 struct describe::data {
-  data(long N) : D(N), mean(1), std(1), min(1), max(1), q(sycl::default_selector{})
-  {}
+  data(long N)
+      : D(N), mean(1), std(1), min(1), max(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<double> D;
   sycl::buffer<double> mean;
@@ -25,28 +25,32 @@ describe::describe(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Describe", pdata->q) << std::endl;
 }
 
-describe::~describe() {};
+describe::~describe(){};
 
 void describe::setup() {
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor mean(pdata->mean, h, sycl::write_only);
-    sycl::accessor std(pdata->std, h, sycl::write_only);
-    sycl::accessor min(pdata->min, h, sycl::write_only);
-    sycl::accessor max(pdata->max, h, sycl::write_only);
-    h.single_task([=]() {
-      mean[0] = 0;
-      std[0] = 0;
-      min[0] = 0;
-      max[0] = 0;
-    });
-  }).wait();
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor mean(pdata->mean, h, sycl::write_only);
+        sycl::accessor std(pdata->std, h, sycl::write_only);
+        sycl::accessor min(pdata->min, h, sycl::write_only);
+        sycl::accessor max(pdata->max, h, sycl::write_only);
+        h.single_task([=]() {
+          mean[0] = 0;
+          std[0] = 0;
+          min[0] = 0;
+          max[0] = 0;
+        });
+      })
+      .wait();
 
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
-    sycl::accessor D(pdata->D, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      D[i] = fabs(static_cast<double>(N)/2.0 - static_cast<double>(i));
-    });
-  }).wait();
+  pdata->q
+      .submit([&, N = this->N](sycl::handler &h) {
+        sycl::accessor D(pdata->D, h, sycl::write_only);
+        h.parallel_for(N, [=](const int i) {
+          D[i] = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
+        });
+      })
+      .wait();
 }
 
 void describe::teardown() {
@@ -61,64 +65,66 @@ describe::result describe::run() {
 // For now, use a sycl::nd_range as a workaround
 #if defined(__INTEL_LLVM_COMPILER) || defined(__clang__)
   // Calculate mean, min and max together
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor D(pdata->D, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->mean, pdata->min, pdata->max),
-                   sycl::reduction(pdata->mean, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
-                   sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
-                   [=](sycl::nd_item<1> it, auto& mean, auto& min, auto& max) {
-      const int i = it.get_global_id(0);
-      if (i < N) {
-        mean += D[i];
-        min.combine(D[i]);
-        max.combine(D[i]);
-      }
-    });
+    h.parallel_for(
+        get_reduction_range(N, pdata->q.get_device(), pdata->mean, pdata->min,
+                            pdata->max),
+        sycl::reduction(pdata->mean, h, std::plus<>(), properties),
+        sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
+        sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
+        [=](sycl::nd_item<1> it, auto &mean, auto &min, auto &max) {
+          const int i = it.get_global_id(0);
+          if (i < N) {
+            mean += D[i];
+            min.combine(D[i]);
+            max.combine(D[i]);
+          }
+        });
   });
 #else
   // Calculate mean, min and max together
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor D(pdata->D, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->mean, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
-                   sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
-                   [=](const int i, auto& mean, auto& min, auto& max) {
-      mean += D[i];
-      min.combine(D[i]);
-      max.combine(D[i]);
-    });
+    h.parallel_for(
+        sycl::range<1>(N),
+        sycl::reduction(pdata->mean, h, std::plus<>(), properties),
+        sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
+        sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
+        [=](const int i, auto &mean, auto &min, auto &max) {
+          mean += D[i];
+          min.combine(D[i]);
+          max.combine(D[i]);
+        });
   });
 #endif
 
   // Finalize the mean on the device
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor mean(pdata->mean, h);
-    h.single_task([=]() {
-      mean[0] /= count;
-    });
+    h.single_task([=]() { mean[0] /= count; });
   });
 
   // Calculate std separately, since it depends on mean
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor D(pdata->D, h, sycl::read_only);
     sycl::accessor mean(pdata->mean, h, sycl::read_only);
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->std, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
-                   [=](const int i, auto& std) {
-      std += ((D[i] - mean[0]) * (D[i] - mean[0])) / static_cast<double>(N);
-    });
+    h.parallel_for(
+        sycl::range<1>(N),
+        sycl::reduction(pdata->std, h, std::plus<>(),
+                        sycl::property::reduction::initialize_to_identity{}),
+        [=](const int i, auto &std) {
+          std += ((D[i] - mean[0]) * (D[i] - mean[0])) / static_cast<double>(N);
+        });
   });
 
   return {
-    .count = count,
-    .mean = pdata->mean.get_host_access()[0],
-    .std = std::sqrt(pdata->std.get_host_access()[0]),
-    .min = pdata->min.get_host_access()[0],
-    .max = pdata->max.get_host_access()[0],
+      .count = count,
+      .mean = pdata->mean.get_host_access()[0],
+      .std = std::sqrt(pdata->std.get_host_access()[0]),
+      .min = pdata->min.get_host_access()[0],
+      .max = pdata->max.get_host_access()[0],
   };
 }
-

--- a/src/sycl/describe.cpp
+++ b/src/sycl/describe.cpp
@@ -10,8 +10,7 @@
 #include "common.hpp"
 
 struct describe::data {
-  data(long N)
-      : D(N), mean(1), std(1), min(1), max(1), q(sycl::default_selector{}) {}
+  data(long N) : D(N), mean(1), std(1), min(1), max(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<double> D;
   sycl::buffer<double> mean;
@@ -46,9 +45,7 @@ void describe::setup() {
   pdata->q
       .submit([&, N = this->N](sycl::handler &h) {
         sycl::accessor D(pdata->D, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) {
-          D[i] = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i));
-        });
+        h.parallel_for(N, [=](const int i) { D[i] = fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
       })
       .wait();
 }
@@ -68,36 +65,32 @@ describe::result describe::run() {
   pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor D(pdata->D, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(
-        get_reduction_range(N, pdata->q.get_device(), pdata->mean, pdata->min,
-                            pdata->max),
-        sycl::reduction(pdata->mean, h, std::plus<>(), properties),
-        sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
-        sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
-        [=](sycl::nd_item<1> it, auto &mean, auto &min, auto &max) {
-          const int i = it.get_global_id(0);
-          if (i < N) {
-            mean += D[i];
-            min.combine(D[i]);
-            max.combine(D[i]);
-          }
-        });
+    h.parallel_for(get_reduction_range(N, pdata->q.get_device(), pdata->mean, pdata->min, pdata->max),
+                   sycl::reduction(pdata->mean, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
+                   sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
+                   [=](sycl::nd_item<1> it, auto &mean, auto &min, auto &max) {
+                     const int i = it.get_global_id(0);
+                     if (i < N) {
+                       mean += D[i];
+                       min.combine(D[i]);
+                       max.combine(D[i]);
+                     }
+                   });
   });
 #else
   // Calculate mean, min and max together
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor D(pdata->D, h, sycl::read_only);
     auto properties = sycl::property::reduction::initialize_to_identity{};
-    h.parallel_for(
-        sycl::range<1>(N),
-        sycl::reduction(pdata->mean, h, std::plus<>(), properties),
-        sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
-        sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
-        [=](const int i, auto &mean, auto &min, auto &max) {
-          mean += D[i];
-          min.combine(D[i]);
-          max.combine(D[i]);
-        });
+    h.parallel_for(sycl::range<1>(N), sycl::reduction(pdata->mean, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->min, h, sycl::minimum<>(), properties),
+                   sycl::reduction(pdata->max, h, sycl::maximum<>(), properties),
+                   [=](const int i, auto &mean, auto &min, auto &max) {
+                     mean += D[i];
+                     min.combine(D[i]);
+                     max.combine(D[i]);
+                   });
   });
 #endif
 
@@ -113,11 +106,8 @@ describe::result describe::run() {
     sycl::accessor mean(pdata->mean, h, sycl::read_only);
     h.parallel_for(
         sycl::range<1>(N),
-        sycl::reduction(pdata->std, h, std::plus<>(),
-                        sycl::property::reduction::initialize_to_identity{}),
-        [=](const int i, auto &std) {
-          std += ((D[i] - mean[0]) * (D[i] - mean[0])) / static_cast<double>(N);
-        });
+        sycl::reduction(pdata->std, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+        [=](const int i, auto &std) { std += ((D[i] - mean[0]) * (D[i] - mean[0])) / static_cast<double>(N); });
   });
 
   return {

--- a/src/sycl/dot.cpp
+++ b/src/sycl/dot.cpp
@@ -52,11 +52,9 @@ double dot::run() {
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor A(pdata->A, h, sycl::read_only);
     sycl::accessor B(pdata->B, h, sycl::read_only);
-    h.parallel_for(
-        sycl::range<1>(N),
-        sycl::reduction(pdata->sum, h, std::plus<>(),
-                        sycl::property::reduction::initialize_to_identity{}),
-        [=](sycl::id<1> i, auto &sum) { sum += A[i] * B[i]; });
+    h.parallel_for(sycl::range<1>(N),
+                   sycl::reduction(pdata->sum, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+                   [=](sycl::id<1> i, auto &sum) { sum += A[i] * B[i]; });
   });
 
   return pdata->sum.get_host_access()[0];

--- a/src/sycl/dot.cpp
+++ b/src/sycl/dot.cpp
@@ -33,10 +33,12 @@ void dot::setup() {
   pdata->q.submit([&, N = this->N](sycl::handler &h) {
     sycl::accessor A(pdata->A, h, sycl::write_only);
     sycl::accessor B(pdata->B, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      A[i] = 1.0 * 1024.0 / static_cast<double>(N);
-      B[i] = 2.0 * 1024.0 / static_cast<double>(N);
-    });
+    h.parallel_for(
+      N,
+      [=](const int i) {
+        A[i] = 1.0 * 1024.0 / static_cast<double>(N);
+        B[i] = 2.0 * 1024.0 / static_cast<double>(N);
+      });
   });
   pdata->q.wait();
 }
@@ -50,9 +52,12 @@ double dot::run() {
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor A(pdata->A, h, sycl::read_only);
     sycl::accessor B(pdata->B, h, sycl::read_only);
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->sum, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
-                   [=](sycl::id<1> i, auto &sum) { sum += A[i] * B[i]; });
+    h.parallel_for(
+      sycl::range<1>(N),
+      sycl::reduction(pdata->sum, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+      [=](sycl::id<1> i, auto &sum) {
+        sum += A[i] * B[i];
+      });
   });
 
   return pdata->sum.get_host_access()[0];

--- a/src/sycl/dot.cpp
+++ b/src/sycl/dot.cpp
@@ -9,8 +9,7 @@
 #include <sycl.hpp>
 
 struct dot::data {
-  data(long N) : A(N), B(N), sum(1), q(sycl::default_selector{})
-  {}
+  data(long N) : A(N), B(N), sum(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<double> A;
   sycl::buffer<double> B;
@@ -25,21 +24,23 @@ dot::dot(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
 dot::~dot() {}
 
 void dot::setup() {
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor sum(pdata->sum, h, sycl::write_only);
-    h.single_task([=]() {
-      sum[0] = 0.0;
-    });
-  }).wait();
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor sum(pdata->sum, h, sycl::write_only);
+        h.single_task([=]() { sum[0] = 0.0; });
+      })
+      .wait();
 
-  pdata->q.submit([&, N=this->N](sycl::handler& h) {
-    sycl::accessor A(pdata->A, h, sycl::write_only);
-    sycl::accessor B(pdata->B, h, sycl::write_only);
-    h.parallel_for(N, [=](const int i) {
-      A[i] = 1.0 * 1024.0 / static_cast<double>(N);
-      B[i] = 2.0 * 1024.0 / static_cast<double>(N);
-    });
-  }).wait();
+  pdata->q
+      .submit([&, N = this->N](sycl::handler &h) {
+        sycl::accessor A(pdata->A, h, sycl::write_only);
+        sycl::accessor B(pdata->B, h, sycl::write_only);
+        h.parallel_for(N, [=](const int i) {
+          A[i] = 1.0 * 1024.0 / static_cast<double>(N);
+          B[i] = 2.0 * 1024.0 / static_cast<double>(N);
+        });
+      })
+      .wait();
 }
 
 void dot::teardown() {
@@ -48,16 +49,15 @@ void dot::teardown() {
 }
 
 double dot::run() {
-  pdata->q.submit([&](sycl::handler& h) {
+  pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor A(pdata->A, h, sycl::read_only);
     sycl::accessor B(pdata->B, h, sycl::read_only);
-    h.parallel_for(sycl::range<1>(N),
-                   sycl::reduction(pdata->sum, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
-                   [=](sycl::id<1> i, auto& sum) {
-      sum += A[i] * B[i];
-    });
+    h.parallel_for(
+        sycl::range<1>(N),
+        sycl::reduction(pdata->sum, h, std::plus<>(),
+                        sycl::property::reduction::initialize_to_identity{}),
+        [=](sycl::id<1> i, auto &sum) { sum += A[i] * B[i]; });
   });
 
   return pdata->sum.get_host_access()[0];
 }
-

--- a/src/sycl/dot.cpp
+++ b/src/sycl/dot.cpp
@@ -24,23 +24,21 @@ dot::dot(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
 dot::~dot() {}
 
 void dot::setup() {
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor sum(pdata->sum, h, sycl::write_only);
-        h.single_task([=]() { sum[0] = 0.0; });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor sum(pdata->sum, h, sycl::write_only);
+    h.single_task([=]() { sum[0] = 0.0; });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&, N = this->N](sycl::handler &h) {
-        sycl::accessor A(pdata->A, h, sycl::write_only);
-        sycl::accessor B(pdata->B, h, sycl::write_only);
-        h.parallel_for(N, [=](const int i) {
-          A[i] = 1.0 * 1024.0 / static_cast<double>(N);
-          B[i] = 2.0 * 1024.0 / static_cast<double>(N);
-        });
-      })
-      .wait();
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor A(pdata->A, h, sycl::write_only);
+    sycl::accessor B(pdata->B, h, sycl::write_only);
+    h.parallel_for(N, [=](const int i) {
+      A[i] = 1.0 * 1024.0 / static_cast<double>(N);
+      B[i] = 2.0 * 1024.0 / static_cast<double>(N);
+    });
+  });
+  pdata->q.wait();
 }
 
 void dot::teardown() {

--- a/src/sycl/field_summary.cpp
+++ b/src/sycl/field_summary.cpp
@@ -44,14 +44,16 @@ void field_summary::setup() {
     sycl::accessor density(pdata->density, h, sycl::write_only);
     sycl::accessor energy(pdata->energy, h, sycl::write_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx, ny), [=](sycl::id<2> jk) {
-      size_t j = jk[0];
-      size_t k = jk[1];
-      volume[j][k] = dx * dy;
-      density[j][k] = 0.2;
-      energy[j][k] = 1.0;
-      pressure[j][k] = (1.4 - 1.0) * 0.2 * 1.0;
-    });
+    h.parallel_for(
+      sycl::range<2>(nx, ny),
+      [=](sycl::id<2> jk) {
+        size_t j = jk[0];
+        size_t k = jk[1];
+        volume[j][k] = dx * dy;
+        density[j][k] = 0.2;
+        energy[j][k] = 1.0;
+        pressure[j][k] = (1.4 - 1.0) * 0.2 * 1.0;
+      });
   });
   pdata->q.wait();
 
@@ -59,25 +61,29 @@ void field_summary::setup() {
     sycl::accessor density(pdata->density, h, sycl::write_only);
     sycl::accessor energy(pdata->energy, h, sycl::write_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx / 2, ny / 5), [=](sycl::id<2> jk) {
-      size_t j = jk[0];
-      size_t k = jk[1];
-      density[j][k] = 1.0;
-      energy[j][k] = 2.5;
-      pressure[j][k] = (1.4 - 1.0) * 1.0 * 2.5;
-    });
+    h.parallel_for(
+      sycl::range<2>(nx / 2, ny / 5),
+      [=](sycl::id<2> jk) {
+        size_t j = jk[0];
+        size_t k = jk[1];
+        density[j][k] = 1.0;
+        energy[j][k] = 2.5;
+        pressure[j][k] = (1.4 - 1.0) * 1.0 * 2.5;
+      });
   });
   pdata->q.wait();
 
   pdata->q.submit([&](sycl::handler &h) {
     sycl::accessor xvel(pdata->xvel, h, sycl::write_only);
     sycl::accessor yvel(pdata->yvel, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx + 1, ny + 1), [=](sycl::id<2> jk) {
-      size_t j = jk[0];
-      size_t k = jk[1];
-      xvel[j][k] = 0.0;
-      yvel[j][k] = 0.0;
-    });
+    h.parallel_for(
+      sycl::range<2>(nx + 1, ny + 1),
+      [=](sycl::id<2> jk) {
+        size_t j = jk[0];
+        size_t k = jk[1];
+        xvel[j][k] = 0.0;
+        yvel[j][k] = 0.0;
+      });
   });
   pdata->q.wait();
 }
@@ -99,32 +105,33 @@ field_summary::reduction_vars field_summary::run() {
     sycl::accessor density(pdata->density, h, sycl::read_only);
     sycl::accessor energy(pdata->energy, h, sycl::read_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
-    h.parallel_for(get_reduction_range(sycl::range<2>(nx, ny), pdata->q.get_device(), pdata->vol, pdata->mass,
-                                       pdata->ie, pdata->ke, pdata->press),
-                   sycl::reduction(pdata->vol, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->mass, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->ie, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->ke, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->press, h, std::plus<>(), properties),
-                   [=](sycl::nd_item<2> it, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
-                     int j = it.get_global_id(0);
-                     int k = it.get_global_id(1);
-                     if (j < nx && k < ny) {
-                       double vsqrd = 0.0;
-                       for (int kv = k; kv <= k + 1; ++kv) {
-                         for (int jv = j; jv <= j + 1; ++jv) {
-                           vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
-                         }
-                       }
-                       double cell_volume = volume[j][k];
-                       double cell_mass = cell_volume * density[j][k];
-                       vol += cell_volume;
-                       mass += cell_mass;
-                       ie += cell_mass * energy[j][k];
-                       ke += cell_mass * 0.5 * vsqrd;
-                       press += cell_volume * pressure[j][k];
-                     }
-                   });
+    h.parallel_for(
+      get_reduction_range(sycl::range<2>(nx, ny), pdata->q.get_device(), pdata->vol, pdata->mass,
+                          pdata->ie, pdata->ke, pdata->press),
+      sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+      sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+      sycl::reduction(pdata->press, h, std::plus<>(), properties),
+      [=](sycl::nd_item<2> it, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
+        int j = it.get_global_id(0);
+        int k = it.get_global_id(1);
+        if (j < nx && k < ny) {
+          double vsqrd = 0.0;
+          for (int kv = k; kv <= k + 1; ++kv) {
+            for (int jv = j; jv <= j + 1; ++jv) {
+              vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
+            }
+          }
+          double cell_volume = volume[j][k];
+          double cell_mass = cell_volume * density[j][k];
+          vol += cell_volume;
+          mass += cell_mass;
+          ie += cell_mass * energy[j][k];
+          ke += cell_mass * 0.5 * vsqrd;
+          press += cell_volume * pressure[j][k];
+        }
+      });
   });
 #else
   pdata->q.submit([&](handler &h) {
@@ -135,28 +142,30 @@ field_summary::reduction_vars field_summary::run() {
     sycl::accessor density(pdata->density, h, sycl::read_only);
     sycl::accessor energy(pdata->energy, h, sycl::read_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
-    h.parallel_for(sycl::range<2>(nx, ny), sycl::reduction(pdata->vol, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->mass, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->ie, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->ke, h, std::plus<>(), properties),
-                   sycl::reduction(pdata->press, h, std::plus<>(), properties),
-                   [=](sycl::id<2> jk, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
-                     int j = jk[0];
-                     int k = jk[1];
-                     double vsqrd = 0.0;
-                     for (int kv = k; kv <= k + 1; ++kv) {
-                       for (int jv = j; jv <= j + 1; ++jv) {
-                         vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
-                       }
-                     }
-                     double cell_volume = volume[j][k];
-                     double cell_mass = cell_volume * density[j][k];
-                     vol += cell_volume;
-                     mass += cell_mass;
-                     ie += cell_mass * energy[j][k];
-                     ke += cell_mass * 0.5 * vsqrd;
-                     press += cell_volume * pressure[j][k];
-                   });
+    h.parallel_for(
+      sycl::range<2>(nx, ny),
+      sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+      sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+      sycl::reduction(pdata->press, h, std::plus<>(), properties),
+      [=](sycl::id<2> jk, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
+        int j = jk[0];
+        int k = jk[1];
+        double vsqrd = 0.0;
+        for (int kv = k; kv <= k + 1; ++kv) {
+          for (int jv = j; jv <= j + 1; ++jv) {
+            vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
+          }
+        }
+        double cell_volume = volume[j][k];
+        double cell_mass = cell_volume * density[j][k];
+        vol += cell_volume;
+        mass += cell_mass;
+        ie += cell_mass * energy[j][k];
+        ke += cell_mass * 0.5 * vsqrd;
+        press += cell_volume * pressure[j][k];
+      });
   });
 #endif
 

--- a/src/sycl/field_summary.cpp
+++ b/src/sycl/field_summary.cpp
@@ -39,50 +39,47 @@ void field_summary::setup() {
   const double dx = 10.0 / static_cast<double>(nx);
   const double dy = 10.0 / static_cast<double>(ny);
 
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor volume(pdata->volume, h, sycl::write_only);
-        sycl::accessor density(pdata->density, h, sycl::write_only);
-        sycl::accessor energy(pdata->energy, h, sycl::write_only);
-        sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-        h.parallel_for(sycl::range<2>(nx, ny), [=](sycl::id<2> jk) {
-          size_t j = jk[0];
-          size_t k = jk[1];
-          volume[j][k] = dx * dy;
-          density[j][k] = 0.2;
-          energy[j][k] = 1.0;
-          pressure[j][k] = (1.4 - 1.0) * 0.2 * 1.0;
-        });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor volume(pdata->volume, h, sycl::write_only);
+    sycl::accessor density(pdata->density, h, sycl::write_only);
+    sycl::accessor energy(pdata->energy, h, sycl::write_only);
+    sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
+    h.parallel_for(sycl::range<2>(nx, ny), [=](sycl::id<2> jk) {
+      size_t j = jk[0];
+      size_t k = jk[1];
+      volume[j][k] = dx * dy;
+      density[j][k] = 0.2;
+      energy[j][k] = 1.0;
+      pressure[j][k] = (1.4 - 1.0) * 0.2 * 1.0;
+    });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor density(pdata->density, h, sycl::write_only);
-        sycl::accessor energy(pdata->energy, h, sycl::write_only);
-        sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-        h.parallel_for(sycl::range<2>(nx / 2, ny / 5), [=](sycl::id<2> jk) {
-          size_t j = jk[0];
-          size_t k = jk[1];
-          density[j][k] = 1.0;
-          energy[j][k] = 2.5;
-          pressure[j][k] = (1.4 - 1.0) * 1.0 * 2.5;
-        });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor density(pdata->density, h, sycl::write_only);
+    sycl::accessor energy(pdata->energy, h, sycl::write_only);
+    sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
+    h.parallel_for(sycl::range<2>(nx / 2, ny / 5), [=](sycl::id<2> jk) {
+      size_t j = jk[0];
+      size_t k = jk[1];
+      density[j][k] = 1.0;
+      energy[j][k] = 2.5;
+      pressure[j][k] = (1.4 - 1.0) * 1.0 * 2.5;
+    });
+  });
+  pdata->q.wait();
 
-  pdata->q
-      .submit([&](sycl::handler &h) {
-        sycl::accessor xvel(pdata->xvel, h, sycl::write_only);
-        sycl::accessor yvel(pdata->yvel, h, sycl::write_only);
-        h.parallel_for(sycl::range<2>(nx + 1, ny + 1), [=](sycl::id<2> jk) {
-          size_t j = jk[0];
-          size_t k = jk[1];
-          xvel[j][k] = 0.0;
-          yvel[j][k] = 0.0;
-        });
-      })
-      .wait();
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor xvel(pdata->xvel, h, sycl::write_only);
+    sycl::accessor yvel(pdata->yvel, h, sycl::write_only);
+    h.parallel_for(sycl::range<2>(nx + 1, ny + 1), [=](sycl::id<2> jk) {
+      size_t j = jk[0];
+      size_t k = jk[1];
+      xvel[j][k] = 0.0;
+      yvel[j][k] = 0.0;
+    });
+  });
+  pdata->q.wait();
 }
 
 void field_summary::teardown() {

--- a/src/sycl/field_summary.cpp
+++ b/src/sycl/field_summary.cpp
@@ -9,15 +9,12 @@
 #include <sycl.hpp>
 
 struct field_summary::data {
-  data(long nx, long ny) : xvel(sycl::range<2>(nx+1, ny+1)),
-                           yvel(sycl::range<2>(nx+1, ny+1)),
-                           volume(sycl::range<2>(nx, ny)),
-                           density(sycl::range<2>(nx, ny)),
-                           energy(sycl::range<2>(nx, ny)),
-                           pressure(sycl::range<2>(nx, ny)),
-                           vol(1), mass(1), ie(1), ke(1), press(1),
-                           q(sycl::default_selector{})
-  {}
+  data(long nx, long ny)
+      : xvel(sycl::range<2>(nx + 1, ny + 1)),
+        yvel(sycl::range<2>(nx + 1, ny + 1)), volume(sycl::range<2>(nx, ny)),
+        density(sycl::range<2>(nx, ny)), energy(sycl::range<2>(nx, ny)),
+        pressure(sycl::range<2>(nx, ny)), vol(1), mass(1), ie(1), ke(1),
+        press(1), q(sycl::default_selector{}) {}
 
   sycl::buffer<double, 2> xvel;
   sycl::buffer<double, 2> yvel;
@@ -41,44 +38,53 @@ field_summary::~field_summary() {}
 
 void field_summary::setup() {
   // Initalise arrays
-  const double dx = 10.0/static_cast<double>(nx);
-  const double dy = 10.0/static_cast<double>(ny);
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
 
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor volume(pdata->volume, h, sycl::write_only);
-    sycl::accessor density(pdata->density, h, sycl::write_only);
-    sycl::accessor energy(pdata->energy, h, sycl::write_only);
-    sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx, ny), [=](sycl::id<2> jk) {
-      size_t j = jk[0]; size_t k = jk[1];
-      volume[j][k] = dx * dy;
-      density[j][k] = 0.2;
-      energy[j][k] = 1.0;
-      pressure[j][k] = (1.4-1.0) * 0.2 * 1.0;
-    });
-  }).wait();
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor volume(pdata->volume, h, sycl::write_only);
+        sycl::accessor density(pdata->density, h, sycl::write_only);
+        sycl::accessor energy(pdata->energy, h, sycl::write_only);
+        sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
+        h.parallel_for(sycl::range<2>(nx, ny), [=](sycl::id<2> jk) {
+          size_t j = jk[0];
+          size_t k = jk[1];
+          volume[j][k] = dx * dy;
+          density[j][k] = 0.2;
+          energy[j][k] = 1.0;
+          pressure[j][k] = (1.4 - 1.0) * 0.2 * 1.0;
+        });
+      })
+      .wait();
 
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor density(pdata->density, h, sycl::write_only);
-    sycl::accessor energy(pdata->energy, h, sycl::write_only);
-    sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx/2, ny/5), [=](sycl::id<2> jk) {
-      size_t j = jk[0]; size_t k = jk[1];
-      density[j][k] = 1.0;
-      energy[j][k] = 2.5;
-      pressure[j][k] = (1.4-1.0) * 1.0 * 2.5;
-    });
-  }).wait();
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor density(pdata->density, h, sycl::write_only);
+        sycl::accessor energy(pdata->energy, h, sycl::write_only);
+        sycl::accessor pressure(pdata->pressure, h, sycl::write_only);
+        h.parallel_for(sycl::range<2>(nx / 2, ny / 5), [=](sycl::id<2> jk) {
+          size_t j = jk[0];
+          size_t k = jk[1];
+          density[j][k] = 1.0;
+          energy[j][k] = 2.5;
+          pressure[j][k] = (1.4 - 1.0) * 1.0 * 2.5;
+        });
+      })
+      .wait();
 
-  pdata->q.submit([&](sycl::handler& h) {
-    sycl::accessor xvel(pdata->xvel, h, sycl::write_only);
-    sycl::accessor yvel(pdata->yvel, h, sycl::write_only);
-    h.parallel_for(sycl::range<2>(nx+1, ny+1), [=](sycl::id<2> jk) {
-      size_t j = jk[0]; size_t k = jk[1];
-      xvel[j][k] = 0.0;
-      yvel[j][k] = 0.0;
-    });
-  }).wait();
+  pdata->q
+      .submit([&](sycl::handler &h) {
+        sycl::accessor xvel(pdata->xvel, h, sycl::write_only);
+        sycl::accessor yvel(pdata->yvel, h, sycl::write_only);
+        h.parallel_for(sycl::range<2>(nx + 1, ny + 1), [=](sycl::id<2> jk) {
+          size_t j = jk[0];
+          size_t k = jk[1];
+          xvel[j][k] = 0.0;
+          yvel[j][k] = 0.0;
+        });
+      })
+      .wait();
 }
 
 void field_summary::teardown() {
@@ -90,7 +96,7 @@ field_summary::reduction_vars field_summary::run() {
 // Intel DPC++ doesn't yet support multiple reductions with sycl::range
 // For now, use a sycl::nd_range as a workaround
 #if defined(__INTEL_LLVM_COMPILER) || defined(__clang__)
-  pdata->q.submit([&, nx=this->nx, ny=this->ny](sycl::handler& h) {
+  pdata->q.submit([&, nx = this->nx, ny = this->ny](sycl::handler &h) {
     auto properties = sycl::property::reduction::initialize_to_identity{};
     sycl::accessor xvel(pdata->xvel, h, sycl::read_only);
     sycl::accessor yvel(pdata->yvel, h, sycl::read_only);
@@ -98,33 +104,39 @@ field_summary::reduction_vars field_summary::run() {
     sycl::accessor density(pdata->density, h, sycl::read_only);
     sycl::accessor energy(pdata->energy, h, sycl::read_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
-    h.parallel_for(get_reduction_range(sycl::range<2>(nx, ny), pdata->q.get_device(), pdata->vol, pdata->mass, pdata->ie, pdata->ke, pdata->press),
-      sycl::reduction(pdata->vol, h, std::plus<>(), properties),
-      sycl::reduction(pdata->mass, h, std::plus<>(), properties),
-      sycl::reduction(pdata->ie, h, std::plus<>(), properties),
-      sycl::reduction(pdata->ke, h, std::plus<>(), properties),
-      sycl::reduction(pdata->press, h, std::plus<>(), properties),
-      [=](sycl::nd_item<2> it, auto& vol, auto& mass, auto& ie, auto& ke, auto& press) {
-      int j = it.get_global_id(0); int k = it.get_global_id(1);
-      if (j < nx && k < ny) {
-        double vsqrd = 0.0;
-        for (int kv = k; kv <= k+1; ++kv) {
-          for (int jv = j; jv <= j+1; ++jv) {
-            vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
-          }
-        }
-        double cell_volume = volume[j][k];
-        double cell_mass = cell_volume * density[j][k];
-        vol += cell_volume;
-        mass += cell_mass;
-        ie += cell_mass * energy[j][k];
-        ke += cell_mass * 0.5 * vsqrd;
-        press += cell_volume * pressure[j][k];
-      }
-    });
+    h.parallel_for(get_reduction_range(sycl::range<2>(nx, ny),
+                                       pdata->q.get_device(), pdata->vol,
+                                       pdata->mass, pdata->ie, pdata->ke,
+                                       pdata->press),
+                   sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->press, h, std::plus<>(), properties),
+                   [=](sycl::nd_item<2> it, auto &vol, auto &mass, auto &ie,
+                       auto &ke, auto &press) {
+                     int j = it.get_global_id(0);
+                     int k = it.get_global_id(1);
+                     if (j < nx && k < ny) {
+                       double vsqrd = 0.0;
+                       for (int kv = k; kv <= k + 1; ++kv) {
+                         for (int jv = j; jv <= j + 1; ++jv) {
+                           vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] +
+                                            yvel[jv][kv] * yvel[jv][kv]);
+                         }
+                       }
+                       double cell_volume = volume[j][k];
+                       double cell_mass = cell_volume * density[j][k];
+                       vol += cell_volume;
+                       mass += cell_mass;
+                       ie += cell_mass * energy[j][k];
+                       ke += cell_mass * 0.5 * vsqrd;
+                       press += cell_volume * pressure[j][k];
+                     }
+                   });
   });
 #else
-  pdata->q.submit([&](handler& h) {
+  pdata->q.submit([&](handler &h) {
     auto properties = sycl::property::reduction::initialize_to_identity{};
     sycl::accessor xvel(pdata->xvel, h, sycl::read_only);
     sycl::accessor yvel(pdata->yvel, h, sycl::read_only);
@@ -133,31 +145,34 @@ field_summary::reduction_vars field_summary::run() {
     sycl::accessor energy(pdata->energy, h, sycl::read_only);
     sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
     h.parallel_for(sycl::range<2>(nx, ny),
-      sycl::reduction(pdata->vol, h, std::plus<>(), properties),
-      sycl::reduction(pdata->mass, h, std::plus<>(), properties),
-      sycl::reduction(pdata->ie, h, std::plus<>(), properties),
-      sycl::reduction(pdata->ke, h, std::plus<>(), properties),
-      sycl::reduction(pdata->press, h, std::plus<>(), properties),
-      [=](sycl::id<2> jk, auto& vol, auto& mass, auto& ie, auto& ke, auto& press) {
-      int j = jk[0]; int k = jk[1];
-      double vsqrd = 0.0;
-      for (int kv = k; kv <= k+1; ++kv) {
-        for (int jv = j; jv <= j+1; ++jv) {
-          vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
-        }
-      }
-      double cell_volume = volume[j][k];
-      double cell_mass = cell_volume * density[j][k];
-      vol += cell_volume;
-      mass += cell_mass;
-      ie += cell_mass * energy[j][k];
-      ke += cell_mass * 0.5 * vsqrd;
-      press += cell_volume * pressure[j][k];
-    });
+                   sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->press, h, std::plus<>(), properties),
+                   [=](sycl::id<2> jk, auto &vol, auto &mass, auto &ie,
+                       auto &ke, auto &press) {
+                     int j = jk[0];
+                     int k = jk[1];
+                     double vsqrd = 0.0;
+                     for (int kv = k; kv <= k + 1; ++kv) {
+                       for (int jv = j; jv <= j + 1; ++jv) {
+                         vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] +
+                                          yvel[jv][kv] * yvel[jv][kv]);
+                       }
+                     }
+                     double cell_volume = volume[j][k];
+                     double cell_mass = cell_volume * density[j][k];
+                     vol += cell_volume;
+                     mass += cell_mass;
+                     ie += cell_mass * energy[j][k];
+                     ke += cell_mass * 0.5 * vsqrd;
+                     press += cell_volume * pressure[j][k];
+                   });
   });
 #endif
 
-  return { pdata->vol.get_host_access()[0], pdata->mass.get_host_access()[0], pdata->ie.get_host_access()[0], pdata->ke.get_host_access()[0], pdata->press.get_host_access()[0] };
+  return {pdata->vol.get_host_access()[0], pdata->mass.get_host_access()[0],
+          pdata->ie.get_host_access()[0], pdata->ke.get_host_access()[0],
+          pdata->press.get_host_access()[0]};
 }
-
-


### PR DESCRIPTION
This is the result of running clang-format on all the files. I used version 10.0.0 with the default options.

A few things might require manual adjustment, but be good to discuss them:

## Inconsistent line breaks for Kokkos lambda functions.

There are a few varieties:
```
Kokkos::parallel_for(
    N, KOKKOS_LAMBDA(const int i) {
      // body
    });
```

```
Kokkos::parallel_reduce(
      N,
      KOKKOS_LAMBDA(const int i, reducer_type<T> &smallest) {
        // body
      },
      ComplexMin<T, Kokkos::HostSpace>(smallest));

```

```
  Kokkos::parallel_for(
      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {nx, ny}),
      KOKKOS_LAMBDA(const int j, const int k) {
        // body
      });
```

I think we should consistently go for:
```
1:  Kokkos::parallel_for(
2:    The range: could be N, or a long MDRangePolicy 
3:    KOKKOS_LAMBDA(args) {
4:      lambda body
5:    }); or },
6:    optional reduction variable );
```

## OpenMP target

### Array syntax
The main problem is the formatting of OpenMP array syntax, e.g.:
```
#pragma omp target enter data map(alloc : C [0:N])
```

I think these need manually fixing to this:
```
#pragma omp target enter data map(alloc: C[0:N])
```

### Reduction clauses
It inconsistently formats the `reduction()` clause:
```
#pragma omp target teams distribute parallel for reduction(+:vol, mass, ie, ke, press)
   for (long k = 0; k < ny; ++k) {
#pragma omp simd reduction(+ : vol, mass, ie, ke, press)
    for (long j = 0; j < nx; ++j) {
```
This is a bit strange, and I think neither format is nice.
I'd go for:
```
#pragma omp target teams distribute parallel for reduction(+: vol, mass, ie, ke, press)
   for (long k = 0; k < ny; ++k) {
#pragma omp simd reduction(+: vol, mass, ie, ke, press)
    for (long j = 0; j < nx; ++j) {
```

### Column zero
Another quirk is all the pragmas start in column zero.
```
#pragma omp parallel for
  for (long i = 0; i < N; ++i) {
```
I don't think I have a strong opinion on this given we don't nest OpenMP deeply.


## RAJA

Like with Kokkos, how the parallel loop, range, and lambda get split across lines is a bit inconsistent:
```
  RAJA::forall<policy>(
      RAJA::RangeSegment(0, N), [=] RAJA_DEVICE(RAJA::Index_type i) {
```
If the lambda body is short, then it is split differently.
```
  RAJA::forall<policy>(RAJA::RangeSegment(0, N),
                       [=] RAJA_DEVICE(RAJA::Index_type i) { sum += C[i]; });
```
I think we should change this to follow the same breaking as my suggestion for Kokkos above.

### RAJA_RESTRICT

The `RAJA_RESTRICT` macro causes strange spacing:
```
double *RAJA_RESTRICT A = pdata->A;
```

I think my original line was better:
```
double * RAJA_RESTRICT A = pdata->A;
```

## SYCL

### Wait

As discussed, the `.wait();` gets its own line. I think this is probably fair to count as `Kokkos::fence();` is placed on its own line, and we want to count the manual "I need to synchronise".

### Submit

I think this looks pretty nasty though:
```
  pdata->q
      .submit([&](sycl::handler &h) {
```
I'd suggest this is put on one line:
```
  pdata->q.submit([&](sycl::handler &h) {
```

### Parallel for

If we take the approach for Kokkos and RAJA to put the range on a new line, do we do the same for SYCL? Currently, the code formats with the range on the same line as the `parallel_for`.
```
h.parallel_for(N, [=](const int i) {
```

There are also times when the lambda is on a new line:
```
    h.parallel_for(
        sycl::range<1>(N),
        sycl::reduction(pdata->mean, h, std::plus<>(), properties),
        // more reduction variables
        [=](const int i, auto &mean, auto &min, auto &max) {
```

I think we should be consistent across all 3 lambda-based languages and follow the format I suggested for all 3.


