### PR TITLE
Add FP32 variants of Complex tests

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,17 @@ const auto LINE = "------------------------------------------------------------"
 
 #include "util.hpp"
 
-enum class Benchmark { dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe };
+enum class Benchmark {
+  dot,
+  complex_sum,
+  complex_sum_soa,
+  complex_min,
+  complex_sum_fp32,
+  complex_sum_soa_fp32,
+  complex_min_fp32,
+  field_summary,
+  describe
+};
 
 // Choose the benchmark based on the input argument given from the command line
 Benchmark select_benchmark(const std::string name) {
@@ -35,6 +45,12 @@ Benchmark select_benchmark(const std::string name) {
     return Benchmark::complex_sum_soa;
   else if (name == "complex_min")
     return Benchmark::complex_min;
+  else if (name == "complex_sum_fp32")
+    return Benchmark::complex_sum_fp32;
+  else if (name == "complex_sum_soa_fp32")
+    return Benchmark::complex_sum_soa_fp32;
+  else if (name == "complex_min_fp32")
+    return Benchmark::complex_min_fp32;
   else if (name == "field_summary")
     return Benchmark::field_summary;
   else if (name == "describe")
@@ -100,6 +116,7 @@ int main(int argc, char *argv[]) {
               << std::endl
               << "Valid benchmarks:" << std::endl
               << "  dot, complex_sum, complex_sum_soa, complex_min, "
+              << "complex_sum_fp32, complex_sum_soa_fp32, complex_min_fp32, "
                  "field_summary, describe"
               << std::endl;
     exit(EXIT_FAILURE);
@@ -264,6 +281,125 @@ int main(int argc, char *argv[]) {
     auto teardown_stop = clock::now();
 
     print_timing("Complex Min", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 cmin.gibibytes());
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Run Complex Sum FP32 Benchmark
+  //////////////////////////////////////////////////////////////////////////////
+  else if (run == Benchmark::complex_sum_fp32) {
+    check_for_option(argc);
+    long N = get_problem_size(argv[2]);
+
+    auto construct_start = clock::now();
+    complex_sum<float> csum(N);
+    auto construct_stop = clock::now();
+
+    auto setup_start = clock::now();
+    csum.setup();
+    auto setup_stop = clock::now();
+
+    auto run_start = clock::now();
+    std::complex<float> r = csum.run();
+    auto run_stop = clock::now();
+
+    // Check solution
+    auto check_start = clock::now();
+    if (std::abs(r - csum.expect()) > std::numeric_limits<float>::epsilon() * 100.0) {
+      std::cerr << "Complex Sum FP32: result incorrect" << std::endl
+                << "Expected: " << csum.expect() << std::endl
+                << "Result: " << r << std::endl
+                << "Difference: " << std::abs(r - csum.expect()) << std::endl
+                << "Eps: " << std::numeric_limits<double>::epsilon() << std::endl;
+    }
+    auto check_stop = clock::now();
+
+    auto teardown_start = clock::now();
+    csum.teardown();
+    auto teardown_stop = clock::now();
+
+    print_timing("Complex Sum FP32", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 csum.gibibytes());
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Run Complex Sum SoA FP32 Benchmark
+  //////////////////////////////////////////////////////////////////////////////
+  else if (run == Benchmark::complex_sum_soa_fp32) {
+    check_for_option(argc);
+    long N = get_problem_size(argv[2]);
+
+    auto construct_start = clock::now();
+    complex_sum_soa<float> csum(N);
+    auto construct_stop = clock::now();
+
+    auto setup_start = clock::now();
+    csum.setup();
+    auto setup_stop = clock::now();
+
+    auto run_start = clock::now();
+    std::tuple<float, float> r = csum.run();
+    auto run_stop = clock::now();
+
+    // Check solution
+    auto check_start = clock::now();
+    if (std::abs(std::get<0>(r) - std::get<0>(csum.expect())) > std::numeric_limits<float>::epsilon() * 100.0 ||
+        std::abs(std::get<1>(r) - std::get<1>(csum.expect())) > std::numeric_limits<float>::epsilon() * 100.0) {
+      std::cerr << "Complex Sum SoA: result incorrect" << std::endl
+                << "Expected: " << std::get<0>(csum.expect()) << "+ i" << std::get<1>(csum.expect()) << std::endl
+                << "Result:   " << std::get<0>(r) << "+ i" << std::get<1>(r) << std::endl
+                << "Difference: " << std::abs(std::get<0>(r) - std::get<0>(csum.expect())) << " and "
+                << std::abs(std::get<1>(r) - std::get<1>(csum.expect())) << std::endl
+                << "Eps: " << std::numeric_limits<float>::epsilon() << std::endl;
+    }
+    auto check_stop = clock::now();
+
+    auto teardown_start = clock::now();
+    csum.teardown();
+    auto teardown_stop = clock::now();
+
+    print_timing("Complex Sum SoA FP32", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 csum.gibibytes());
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Run Complex Min FP32 Benchmark
+  //////////////////////////////////////////////////////////////////////////////
+  else if (run == Benchmark::complex_min_fp32) {
+    check_for_option(argc);
+    long N = get_problem_size(argv[2]);
+
+    auto construct_start = clock::now();
+    complex_min<float> cmin(N);
+    auto construct_stop = clock::now();
+
+    auto setup_start = clock::now();
+    cmin.setup();
+    auto setup_stop = clock::now();
+
+    auto run_start = clock::now();
+    std::complex<float> r = cmin.run();
+    auto run_stop = clock::now();
+
+    // Check solution
+    auto check_start = clock::now();
+    if (std::abs(r - cmin.expect()) > std::numeric_limits<float>::epsilon() * 100.0) {
+      std::cerr << "Complex Min: result incorrect" << std::endl
+                << "Expected: " << cmin.expect() << std::endl
+                << "Result: " << r << std::endl
+                << "Difference: " << std::abs(r - cmin.expect()) << std::endl
+                << "Eps: " << std::numeric_limits<float>::epsilon() << std::endl;
+    }
+    auto check_stop = clock::now();
+
+    auto teardown_start = clock::now();
+    cmin.teardown();
+    auto teardown_stop = clock::now();
+
+    print_timing("Complex Min FP32", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
                  elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
                  cmin.gibibytes());
   }

--- a/src/run_clx.sh
+++ b/src/run_clx.sh
@@ -20,7 +20,7 @@ cmake --build build_omp --parallel
 fi
 
 if [ -f ./build_omp/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa complex_min field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
     ./build_omp/Reduced $b 1gib
   done
 else
@@ -43,7 +43,7 @@ fi
 
 
 if [ -f ./build_kokkos/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa complex_min field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
     ./build_kokkos/Reduced $b 1gib
   done
 else
@@ -65,7 +65,7 @@ fi
 
 
 if [ -f ./build_raja/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_sum_fp32 complex_sum_soa_fp32 field_summary describe; do
     ./build_raja/Reduced $b 1gib
   done
 else
@@ -86,7 +86,7 @@ fi
 export SYCL_DEVICE_FILTER=cpu
 
 if [ -f ./build_sycl/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa complex_min field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
     ./build_sycl/Reduced $b 1gib
   done
 else

--- a/src/run_rome.sh
+++ b/src/run_rome.sh
@@ -15,7 +15,7 @@ COMPILER=CC
 C_COMPILER=cc
 
 # Try with AOCC
-if true; then
+if false ; then
   module load aocc/2.3
   COMPILER=clang++
   C_COMPILER=clang
@@ -34,7 +34,7 @@ fi
 
 
 if [ -f ./build_omp/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa complex_min field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
     ./build_omp/Reduced $b 1gib
   done
 else
@@ -56,13 +56,14 @@ fi
 
 
 if [ -f ./build_kokkos/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa complex_min field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
     ./build_kokkos/Reduced $b 1gib
   done
 else
   echo "Build failed"
   exit 1
 fi
+
 
 # Build RAJA
 if $build; then
@@ -76,7 +77,7 @@ cmake --build build_raja --parallel
 fi
 
 if [ -f ./build_raja/Reduced ]; then
-  for b in dot complex_sum complex_sum_soa field_summary describe; do
+  for b in dot complex_sum complex_sum_soa complex_sum_fp32 complex_sum_soa_fp32 field_summary describe; do
     ./build_raja/Reduced $b 1gib
   done
 else
@@ -84,3 +85,24 @@ else
   exit 1
 fi
 
+
+exit
+# Build SYCL
+source $HOME/intel/oneapi/setvars.sh
+source dpcpp_compiler/startup.sh
+
+if $build; then
+cmake -H. -Bbuild_sycl -DMODEL=SYCL -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-fsycl -fsycl-unnamed-lambda'
+cmake --build build_sycl --parallel
+fi
+
+export SYCL_DEVICE_FILTER=cpu
+
+if [ -f ./build_sycl/Reduced ]; then
+  for b in dot complex_sum complex_sum_soa complex_min complex_sum_fp32 complex_sum_soa_fp32 complex_min_fp32 field_summary describe; do
+    ./build_sycl/Reduced $b 1gib
+  done
+else
+  echo "Build failed"
+  exit 1
+fi


### PR DESCRIPTION
Current challenges with RAJA implementation are preventing merge:

RAJA's `Real_type` can only be `double` or `float`, and determined when RAJA itself is built. RAJA's `Complex_type` is always `std::complex<RAJA::Real_type>`. So we can't template on FP type.