### PR TITLE
Add oneDPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a collection of key reduction kernel patterns collated from other benchm
     - [Kokkos](#kokkos-version)
     - [RAJA](#raja-version)
     - [SYCL](#sycl-version)
+    - [oneDPL](#onedpl-version)
 - [Organisation](#organisation)
 - [Citing](#citing)
 
@@ -42,7 +43,7 @@ Each library implements the benchmark kernels.
 
 Build using CMake:
 
-    cmake -Bbuild -H. -DMODEL=<model>    # Valid: OpenMP, Kokkos, RAJA, OpenMP-target, SYCL
+    cmake -Bbuild -H. -DMODEL=<model>    # Valid: OpenMP, Kokkos, RAJA, OpenMP-target, SYCL, oneDPL
     cmake --build build
 
 ### OpenMP version ###
@@ -53,7 +54,7 @@ No extra stages are required to build with OpenMP (for the CPU).
 The `MODEL` name is `OpenMP-target`; you must also specify `OMP_TARGET` to indicate which backend to use. Currently, only `Intel` is supported.
 
 We recommend installing oneAPI to use the Intel backend. The [HPC Kit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit/download.html) is needed for OpenMP. Remember to run `/opt/intel/oneapi/setvars.sh` (or wherever you have installed it) before building / running.
-    
+
  | Backend | Options                                                              |
  | ------- | ---------------------------------------------------------------------|
  | Intel   | `-DMODEL=OpenMP-target -DOMP_TARGET=Intel -DCMAKE_CXX_COMPILER=icpx` |
@@ -86,7 +87,17 @@ This code builds Kokkos inline.
 
 We recommend installing the oneAPI [basekit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit/download.html). Remember to run `/opt/intel/oneAPI/setvars.sh` (or wherever you have installed it) before building / running.
 
-We also recommend using a recent 'nightly' build of the oneAPI DPC++ compiler, which can be found [here](https://github.com/intel/llvm/releases) (see the 'assets' arrow and download `dpcpp_compiler.tar.gz`.) When you have untarred the package, you should `source <path-to-nightly>/startup.sh`. 
+We also recommend using a recent 'nightly' build of the oneAPI DPC++ compiler, which can be found [here](https://github.com/intel/llvm/releases) (see the 'assets' arrow and download `dpcpp_compiler.tar.gz`.) When you have untarred the package, you should `source <path-to-nightly>/startup.sh`.
+
+| Toolchain | Options                                                                                                  |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| oneAPI    | `-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-fsycl -fsycl-unnamed-lambda'`                          |
+
+### oneDPL version ###
+
+We recommend installing the oneAPI [basekit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit/download.html). Remember to run `/opt/intel/oneAPI/setvars.sh` (or wherever you have installed it) before building / running.
+
+This code has only been tested with the 2021.3 release of oneAPI.
 
 | Toolchain | Options                                                                                                  |
 | --------- | -------------------------------------------------------------------------------------------------------- |
@@ -134,4 +145,3 @@ Using this approach we can avoid templating the main driver code, and supply dif
 ## Citing ##
 
 To be announced.
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.17)
 
 if (MODEL STREQUAL "SYCL")
   set(CMAKE_CXX_STANDARD 17)
+elif (MODEL STREQUAL "oneDPL")
+  set(CMAKE_CXX_STANDARD 17)
 else()
   set(CMAKE_CXX_STANDARD 14)
 endif()
@@ -69,6 +71,13 @@ elseif (MODEL STREQUAL "SYCL")
 
   target_link_libraries(Reduced PUBLIC implement_sycl)
 
+elseif (MODEL STREQUAL "oneDPL")
+  file(GLOB oneDPL_bench_src CONFIGURE_DEPENDS oneDPL/*.cpp)
+  add_library(implement_oneDPL ${oneDPL_bench_src})
+
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_TBB_PAR_BACKEND=0 -DONEDPL_MODEL") # workaround for oneDPL
+
+  target_link_libraries(Reduced PUBLIC implement_oneDPL)
 
 elseif(MODEL STREQUAL "Kokkos")
   file(GLOB kokkos_bench_src CONFIGURE_DEPENDS kokkos/*.cpp)
@@ -137,4 +146,3 @@ else()
   message(FATAL_ERROR "Please select a model to build: -DMODEL=<model>")
 
 endif()
-

--- a/src/format.sh
+++ b/src/format.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-clang-format -i *.hpp *.cpp kokkos/*.cpp omp/*.cpp omp-target/*.cpp omp-target/*.hpp raja/*.cpp sycl/*.cpp sycl/*.hpp
-
+clang-format -i *.hpp *.cpp kokkos/*.cpp omp/*.cpp omp-target/*.cpp omp-target/*.hpp raja/*.cpp sycl/*.cpp sycl/*.hpp oneDPL/*.cpp

--- a/src/oneDPL/complex_min.cpp
+++ b/src/oneDPL/complex_min.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <limits>
+
+#include "../complex_min.hpp"
+#include "../sycl/common.hpp"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+template <typename T>
+struct complex_min<T>::data {
+  data(long N) : C(N), q(sycl::default_selector()) {}
+
+  sycl::buffer<std::complex<T>> C;
+  sycl::queue q;
+};
+
+template <typename T>
+complex_min<T>::complex_min(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Complex Min", pdata->q) << std::endl;
+}
+
+template <typename T>
+complex_min<T>::~complex_min() {}
+
+template <typename T>
+void complex_min<T>::setup() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  oneapi::dpl::transform(exec_p,
+                         oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(N),
+                         oneapi::dpl::begin(pdata->C),
+                         [=](const auto &i) {
+                           const T v = fabs(static_cast<T>(N) / 2.0 - static_cast<T>(i));
+                           return std::complex<T>{v, v};
+                         });
+}
+
+template <typename T>
+void complex_min<T>::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+template <typename T>
+std::complex<T> complex_min<T>::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  return oneapi::dpl::reduce(exec_p,
+                             oneapi::dpl::begin(pdata->C), oneapi::dpl::end(pdata->C),
+                             std::complex<T>(),
+                             [=](const auto &lhs, const auto &rhs) { return (abs(lhs) < abs(rhs)) ? lhs : rhs; });
+}
+
+template struct complex_min<double>;
+template struct complex_min<float>;

--- a/src/oneDPL/complex_sum.cpp
+++ b/src/oneDPL/complex_sum.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "../complex_sum.hpp"
+#include "../sycl/common.hpp"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+template <typename T>
+struct complex_sum<T>::data {
+  data(long N) : C(N), q(sycl::default_selector()) {}
+
+  sycl::buffer<std::complex<T>> C;
+  sycl::queue q;
+};
+
+template <typename T>
+complex_sum<T>::complex_sum(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Complex Sum", pdata->q) << std::endl;
+}
+
+template <typename T>
+complex_sum<T>::~complex_sum() {}
+
+template <typename T>
+void complex_sum<T>::setup() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+
+  oneapi::dpl::fill(exec_p,
+                    oneapi::dpl::begin(pdata->C), oneapi::dpl::end(pdata->C),
+                    std::complex<T>(2.0 * 1024.0 / static_cast<T>(N), 2.0 * 1024.0 / static_cast<T>(N)));
+}
+
+template <typename T>
+void complex_sum<T>::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+template <typename T>
+std::complex<T> complex_sum<T>::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  return oneapi::dpl::reduce(exec_p,
+                             oneapi::dpl::begin(pdata->C), oneapi::dpl::end(pdata->C),
+                             std::complex<T>());
+}
+
+template struct complex_sum<double>;
+template struct complex_sum<float>;

--- a/src/oneDPL/complex_sum_soa.cpp
+++ b/src/oneDPL/complex_sum_soa.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "../complex_sum_soa.hpp"
+#include "../sycl/common.hpp"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+template <typename T>
+struct complex_sum_soa<T>::data {
+  data(long N) : real(N), imag(N), q(sycl::default_selector()) {}
+
+  sycl::buffer<T> real;
+  sycl::buffer<T> imag;
+
+  sycl::queue q;
+};
+
+template <typename T>
+complex_sum_soa<T>::complex_sum_soa(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Complex Sum SoA", pdata->q) << std::endl;
+}
+
+#define FUSE_KERNELS
+
+template <typename T>
+complex_sum_soa<T>::~complex_sum_soa() {}
+
+template <typename T>
+void complex_sum_soa<T>::setup() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  const T val = 2.0 * 1024.0 / static_cast<T>(N);
+#ifdef FUSE_KERNELS
+#ifdef ZIP_FILL
+  auto output = oneapi::dpl::make_zip_iterator(oneapi::dpl::begin(pdata->real), oneapi::dpl::begin(pdata->imag));
+  oneapi::dpl::fill(exec_p,
+                    output, output + N,
+                    std::make_tuple(val, val));
+#else
+  auto output = oneapi::dpl::make_zip_iterator(oneapi::dpl::begin(pdata->real), oneapi::dpl::begin(pdata->imag));
+  oneapi::dpl::transform(exec_p,
+                         oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(N),
+                         output,
+                         [=](const auto &) { return std::make_tuple(val, val); });
+#endif // ZIP_FILL
+#else
+  oneapi::dpl::fill(exec_p,
+                    oneapi::dpl::begin(pdata->real), oneapi::dpl::end(pdata->real),
+                    2.0 * 1024.0 / static_cast<T>(N));
+  oneapi::dpl::fill(exec_p,
+                    oneapi::dpl::begin(pdata->imag), oneapi::dpl::end(pdata->imag),
+                    2.0 * 1024.0 / static_cast<T>(N));
+#endif // FUSE_KERNELS
+}
+
+template <typename T>
+void complex_sum_soa<T>::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+template <typename T>
+std::tuple<T, T> complex_sum_soa<T>::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+#ifdef FUSE_KERNELS
+  auto input = oneapi::dpl::make_zip_iterator(oneapi::dpl::begin(pdata->real), oneapi::dpl::begin(pdata->imag));
+  return oneapi::dpl::reduce(exec_p,
+                             input, input + N,
+                             std::make_tuple(T(), T()), [=](const auto &l, const auto &r) {
+                                 return std::make_tuple(std::get<0>(l) + std::get<0>(r), std::get<1>(l) + std::get<1>(r));
+                             });
+#else
+  return {
+      oneapi::dpl::reduce(exec_p,
+                          oneapi::dpl::begin(pdata->real), oneapi::dpl::end(pdata->real)),
+      oneapi::dpl::reduce(exec_p,
+                          oneapi::dpl::begin(pdata->imag), oneapi::dpl::end(pdata->imag)),
+  };
+#endif // FUSE_KERNELS
+}
+
+template struct complex_sum_soa<double>;
+template struct complex_sum_soa<float>;

--- a/src/oneDPL/describe.cpp
+++ b/src/oneDPL/describe.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <limits>
+
+#include "../describe.hpp"
+#include "../sycl/common.hpp"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+struct describe::data {
+  data(long N) : D(N), q(sycl::default_selector()) {}
+
+  sycl::buffer<double> D;
+  sycl::queue q;
+};
+
+describe::describe(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Describe", pdata->q) << std::endl;
+}
+
+describe::~describe(){};
+
+void describe::setup() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  oneapi::dpl::transform(exec_p, oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(N),
+                         oneapi::dpl::begin(pdata->D),
+                         [=](const auto &i) { return fabs(static_cast<double>(N) / 2.0 - static_cast<double>(i)); });
+}
+
+void describe::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+struct reduce_data0 {
+  reduce_data0(){};
+
+  // need this constructor to do conversion dictated by transform below
+  reduce_data0(double v) : sum(v), min(v), max(v){};
+
+  double sum;
+  double min;
+  double max;
+};
+
+describe::result describe::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+
+  const reduce_data0 pass1 = oneapi::dpl::reduce(exec_p,
+                                                 oneapi::dpl::begin(pdata->D), oneapi::dpl::end(pdata->D),
+                                                 reduce_data0(0.0),
+                                                 [](const reduce_data0 &l, const reduce_data0 &r) {
+                                                   reduce_data0 o;
+                                                   o.sum = l.sum + r.sum;
+                                                   o.min = std::min(l.min, r.min);
+                                                   o.max = std::max(l.max, r.max);
+                                                   return o;
+                                                 });
+  const double mean = pass1.sum / N;
+  const double var = oneapi::dpl::transform_reduce(
+      exec_p,
+      oneapi::dpl::begin(pdata->D), oneapi::dpl::end(pdata->D), 0.0,
+      std::plus<double>(),
+      [mean, N = this->N](const double v) { return (v - mean) * (v - mean) / static_cast<double>(N); });
+
+  return {.count = N, .mean = mean, .std = std::sqrt(var), .min = pass1.min, .max = pass1.max};
+}

--- a/src/oneDPL/dot.cpp
+++ b/src/oneDPL/dot.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "../dot.hpp"
+#include "../sycl/common.hpp"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+struct dot::data {
+  data(long N) : A(N), B(N), q(sycl::default_selector()) {}
+
+  sycl::buffer<double> A;
+  sycl::buffer<double> B;
+  sycl::queue q;
+};
+
+dot::dot(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Dot", pdata->q) << std::endl;
+}
+
+dot::~dot() {}
+
+void dot::setup() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  oneapi::dpl::fill(exec_p,
+                    oneapi::dpl::begin(pdata->A), oneapi::dpl::end(pdata->A),
+                    1.0 * 1024.0 / static_cast<double>(N));
+  oneapi::dpl::fill(exec_p,
+                    oneapi::dpl::begin(pdata->B), oneapi::dpl::end(pdata->B),
+                    2.0 * 1024.0 / static_cast<double>(N));
+}
+
+void dot::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+double dot::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+  return oneapi::dpl::transform_reduce(exec_p,
+                                       oneapi::dpl::begin(pdata->A), oneapi::dpl::end(pdata->A),
+                                       oneapi::dpl::begin(pdata->B),
+                                       0.0);
+}

--- a/src/oneDPL/field_summary.cpp
+++ b/src/oneDPL/field_summary.cpp
@@ -1,0 +1,387 @@
+// Copyright (c) 2021 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include "../field_summary.hpp"
+#include "../sycl/common.hpp"
+
+#include <iostream>
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+#define ONEDPL_BUFFERS
+
+#ifdef ONEDPL_BUFFERS
+struct field_summary::data {
+  data(long nx, long ny)
+      : xvel(sycl::range<2>(nx + 1, ny + 1)), yvel(sycl::range<2>(nx + 1, ny + 1)), volume(sycl::range<2>(nx, ny)),
+        density(sycl::range<2>(nx, ny)), energy(sycl::range<2>(nx, ny)), pressure(sycl::range<2>(nx, ny)), vol(1),
+        mass(1), ie(1), ke(1), press(1), q(sycl::default_selector()) {}
+
+  sycl::buffer<double, 2> xvel;
+  sycl::buffer<double, 2> yvel;
+  sycl::buffer<double, 2> volume;
+  sycl::buffer<double, 2> density;
+  sycl::buffer<double, 2> energy;
+  sycl::buffer<double, 2> pressure;
+  sycl::buffer<double> vol;
+  sycl::buffer<double> mass;
+  sycl::buffer<double> ie;
+  sycl::buffer<double> ke;
+  sycl::buffer<double> press;
+  sycl::queue q;
+};
+
+field_summary::field_summary() : pdata{std::make_unique<data>(nx, ny)} {
+  std::cout << config_string("Field Summary", pdata->q) << std::endl;
+}
+
+field_summary::~field_summary() {}
+
+template <typename IP, int D, int S>
+struct idx_helper {
+  static constexpr int P = D - S;
+
+  static void recover(std::array<IP, D> &res, IP idx, const std::array<IP, D> &limits) {
+    res[P] = idx / limits[P];
+    idx_helper<IP, D, S - 1>::recover(res, idx - res[P] * limits[P], limits);
+  }
+};
+
+template <typename IP, int D>
+struct idx_helper<IP, D, 1> {
+  static void recover(std::array<IP, D> &res, IP idx, const std::array<IP, D> &limits) { res[D - 1] = idx; }
+};
+
+template <typename IP, int D>
+std::array<IP, D> recover_idx(IP idx, const std::array<IP, D> &limits) {
+  std::array<IP, D> res;
+  idx_helper<IP, D, D>::recover(res, idx, limits);
+  return res;
+}
+
+void field_summary::setup() {
+  // Initalise arrays
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+
+  sycl::buffer<double, 1> flat_density(pdata->density.reinterpret<double, 1>());
+  std::array<long, 2> limits(
+      {static_cast<long>(pdata->density.get_range()[0]), static_cast<long>(pdata->density.get_range()[1])});
+  oneapi::dpl::transform(exec_p, oneapi::dpl::counting_iterator(0L),
+                         oneapi::dpl::counting_iterator(limits[0] * limits[1]), oneapi::dpl::begin(flat_density),
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return 1.0;
+                           } else {
+                             return 0.2;
+                           }
+                         });
+
+  sycl::buffer<double, 1> flat_energy(pdata->energy.reinterpret<double, 1>());
+  oneapi::dpl::transform(exec_p, oneapi::dpl::counting_iterator(0L),
+                         oneapi::dpl::counting_iterator(limits[0] * limits[1]), oneapi::dpl::begin(flat_energy),
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return 2.5;
+                           } else {
+                             return 1.0;
+                           }
+                         });
+
+  sycl::buffer<double, 1> flat_pressure(pdata->pressure.reinterpret<double, 1>());
+  oneapi::dpl::transform(exec_p, oneapi::dpl::counting_iterator(0L),
+                         oneapi::dpl::counting_iterator(limits[0] * limits[1]), oneapi::dpl::begin(flat_pressure),
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return (1.4 - 1.0) * 1.0 * 2.5;
+                           } else {
+                             return (1.4 - 1.0) * 0.2 * 1.0;
+                           }
+                         });
+
+  sycl::buffer<double, 1> flat_volume(pdata->volume.reinterpret<double, 1>());
+  oneapi::dpl::fill(exec_p, oneapi::dpl::begin(flat_volume), oneapi::dpl::end(flat_volume), dx * dy);
+
+  sycl::buffer<double, 1> flat_xvel(pdata->xvel.reinterpret<double, 1>());
+  oneapi::dpl::fill(exec_p, oneapi::dpl::begin(flat_xvel), oneapi::dpl::end(flat_xvel), 0.0);
+
+  sycl::buffer<double, 1> flat_yvel(pdata->yvel.reinterpret<double, 1>());
+  oneapi::dpl::fill(exec_p, oneapi::dpl::begin(flat_yvel), oneapi::dpl::end(flat_yvel), 0.0);
+}
+
+void field_summary::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+field_summary::reduction_vars field_summary::run() {
+  // This will run if you comment it out, but it's hardly a true oneDPL implementation
+  std::cerr << "Error: oneDPL implementation of field_summary is not functional" << std::endl;
+  exit(1);
+// Intel DPC++ doesn't yet support multiple reductions with sycl::range
+// For now, use a sycl::nd_range as a workaround
+#if defined(__INTEL_LLVM_COMPILER) || defined(__clang__)
+  pdata->q.submit([&, nx = this->nx, ny = this->ny](sycl::handler &h) {
+    auto properties = sycl::property::reduction::initialize_to_identity{};
+    sycl::accessor xvel(pdata->xvel, h, sycl::read_only);
+    sycl::accessor yvel(pdata->yvel, h, sycl::read_only);
+    sycl::accessor volume(pdata->volume, h, sycl::read_only);
+    sycl::accessor density(pdata->density, h, sycl::read_only);
+    sycl::accessor energy(pdata->energy, h, sycl::read_only);
+    sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
+    h.parallel_for(
+      get_reduction_range(sycl::range<2>(nx, ny), pdata->q.get_device(), pdata->vol, pdata->mass,
+                          pdata->ie, pdata->ke, pdata->press),
+      sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+      sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+      sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+      sycl::reduction(pdata->press, h, std::plus<>(), properties),
+      [=](sycl::nd_item<2> it, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
+        int j = it.get_global_id(0);
+        int k = it.get_global_id(1);
+        if (j < nx && k < ny) {
+          double vsqrd = 0.0;
+          for (int kv = k; kv <= k + 1; ++kv) {
+            for (int jv = j; jv <= j + 1; ++jv) {
+              vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
+            }
+          }
+          double cell_volume = volume[j][k];
+          double cell_mass = cell_volume * density[j][k];
+          vol += cell_volume;
+          mass += cell_mass;
+          ie += cell_mass * energy[j][k];
+          ke += cell_mass * 0.5 * vsqrd;
+          press += cell_volume * pressure[j][k];
+        }
+      });
+  });
+#else
+  pdata->q.submit([&](handler &h) {
+    auto properties = sycl::property::reduction::initialize_to_identity{};
+    sycl::accessor xvel(pdata->xvel, h, sycl::read_only);
+    sycl::accessor yvel(pdata->yvel, h, sycl::read_only);
+    sycl::accessor volume(pdata->volume, h, sycl::read_only);
+    sycl::accessor density(pdata->density, h, sycl::read_only);
+    sycl::accessor energy(pdata->energy, h, sycl::read_only);
+    sycl::accessor pressure(pdata->pressure, h, sycl::read_only);
+    h.parallel_for(sycl::range<2>(nx, ny), sycl::reduction(pdata->vol, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->mass, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ie, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->ke, h, std::plus<>(), properties),
+                   sycl::reduction(pdata->press, h, std::plus<>(), properties),
+                   [=](sycl::id<2> jk, auto &vol, auto &mass, auto &ie, auto &ke, auto &press) {
+                     int j = jk[0];
+                     int k = jk[1];
+                     double vsqrd = 0.0;
+                     for (int kv = k; kv <= k + 1; ++kv) {
+                       for (int jv = j; jv <= j + 1; ++jv) {
+                         vsqrd += 0.25 * (xvel[jv][kv] * xvel[jv][kv] + yvel[jv][kv] * yvel[jv][kv]);
+                       }
+                     }
+                     double cell_volume = volume[j][k];
+                     double cell_mass = cell_volume * density[j][k];
+                     vol += cell_volume;
+                     mass += cell_mass;
+                     ie += cell_mass * energy[j][k];
+                     ke += cell_mass * 0.5 * vsqrd;
+                     press += cell_volume * pressure[j][k];
+                   });
+  });
+#endif
+
+  return {pdata->vol.get_host_access()[0], pdata->mass.get_host_access()[0], pdata->ie.get_host_access()[0],
+          pdata->ke.get_host_access()[0], pdata->press.get_host_access()[0]};
+}
+#else
+struct field_summary::data {
+  data(long nx, long ny)
+      : q(sycl::default_selector()), xvel(sycl::malloc_device<double>((nx + 1) * (ny + 1), q)),
+        yvel(sycl::malloc_device<double>((nx + 1) * (ny + 1), q)), volume(sycl::malloc_device<double>((nx) * (ny), q)),
+        density(sycl::malloc_device<double>((nx) * (ny), q)), energy(sycl::malloc_device<double>((nx) * (ny), q)),
+        pressure(sycl::malloc_device<double>((nx) * (ny), q)), vol(sycl::malloc_shared<double>(1, q)),
+        mass(sycl::malloc_shared<double>(1, q)), ie(sycl::malloc_shared<double>(1, q)),
+        ke(sycl::malloc_shared<double>(1, q)), press(sycl::malloc_shared<double>(1, q)) {}
+
+  sycl::queue q;
+  double *xvel;
+  double *yvel;
+  double *volume;
+  double *density;
+  double *energy;
+  double *pressure;
+  double *vol;
+  double *mass;
+  double *ie;
+  double *ke;
+  double *press;
+
+};
+
+field_summary::field_summary() : pdata{std::make_unique<data>(nx, ny)} {
+  std::cout << config_string("Field Summary", pdata->q) << std::endl;
+}
+
+field_summary::~field_summary() {}
+
+template <typename IP, int D, int S>
+struct idx_helper {
+  static constexpr int P = D - S;
+
+  static void recover(std::array<IP, D> &res, IP idx, const std::array<IP, D> &limits) {
+    res[P] = idx / limits[P];
+    idx_helper<IP, D, S - 1>::recover(res, idx - res[P] * limits[P], limits);
+  }
+};
+
+template <typename IP, int D>
+struct idx_helper<IP, D, 1> {
+  static void recover(std::array<IP, D> &res, IP idx, const std::array<IP, D> &limits) { res[D - 1] = idx; }
+};
+
+template <typename IP, int D>
+std::array<IP, D> recover_idx(IP idx, const std::array<IP, D> &limits) {
+  std::array<IP, D> res;
+  idx_helper<IP, D, D>::recover(res, idx, limits);
+  return res;
+}
+
+void field_summary::setup() {
+  // Initalise arrays
+  const double dx = 10.0 / static_cast<double>(nx);
+  const double dy = 10.0 / static_cast<double>(ny);
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+
+  std::array<long, 2> limits = {static_cast<long>(nx), static_cast<long>(ny)};
+
+  oneapi::dpl::transform(exec_p,
+                         oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(limits[0] * limits[1]),
+                         pdata->density,
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return 1.0;
+                           } else {
+                             return 0.2;
+                           }
+                         });
+
+  oneapi::dpl::transform(exec_p,
+                         oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(limits[0] * limits[1]),
+                         pdata->energy,
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return 2.5;
+                           } else {
+                             return 1.0;
+                           }
+                         });
+
+  oneapi::dpl::transform(exec_p,
+                         oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(limits[0] * limits[1]),
+                         pdata->pressure,
+                         [=, nx = this->nx, ny = this->ny](const long &offs) {
+                           const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+                           if (idx[0] < nx / 2 && idx[1] < ny / 5) {
+                             return (1.4 - 1.0) * 1.0 * 2.5;
+                           } else {
+                             return (1.4 - 1.0) * 0.2 * 1.0;
+                           }
+                         });
+
+  oneapi::dpl::fill(exec_p,
+                    pdata->volume, pdata->volume + nx * ny,
+                    dx * dy);
+  oneapi::dpl::fill(exec_p,
+                    pdata->xvel, pdata->xvel + (nx + 1) * (ny + 1),
+                    0.0);
+  oneapi::dpl::fill(exec_p,
+                    pdata->yvel, pdata->yvel + (nx + 1) * (ny + 1),
+                    0.0);
+}
+
+void field_summary::teardown() {
+  sycl::free(pdata->xvel, pdata->q);
+  sycl::free(pdata->yvel, pdata->q);
+  sycl::free(pdata->volume, pdata->q);
+  sycl::free(pdata->density, pdata->q);
+  sycl::free(pdata->energy, pdata->q);
+  sycl::free(pdata->pressure, pdata->q);
+  sycl::free(pdata->vol, pdata->q);
+  sycl::free(pdata->mass, pdata->q);
+  sycl::free(pdata->ie, pdata->q);
+  sycl::free(pdata->ke, pdata->q);
+  sycl::free(pdata->press, pdata->q);
+
+  // NOTE: All the data has been destroyed!
+}
+
+struct summary_helper {
+  summary_helper(){};
+
+  // need this constructor to do conversion dictated by transform below
+  summary_helper(long i) {}
+
+  double vol;
+  double mass;
+  double ie;
+  double ke;
+  double press;
+};
+
+template <>
+struct std::plus<summary_helper> {
+  summary_helper operator()(const summary_helper &l, const summary_helper &r) const {
+    summary_helper o;
+    o.vol = l.vol + r.vol;
+    o.mass = l.mass + r.mass;
+    o.ie = l.ie + r.ie;
+    o.ke = l.ke + r.ke;
+    o.press = l.press + r.press;
+    return o;
+  }
+};
+
+field_summary::reduction_vars field_summary::run() {
+  auto exec_p = oneapi::dpl::execution::make_device_policy(pdata->q);
+
+  const std::array<long, 2> limits{static_cast<long>(nx), static_cast<long>(ny)};
+
+  const summary_helper summ = oneapi::dpl::transform_reduce(
+      exec_p, oneapi::dpl::counting_iterator(0L), oneapi::dpl::counting_iterator(limits[0] * limits[1]),
+      summary_helper(), std::plus<summary_helper>(),
+      [limits = limits, nx = this->nx, ny = this->ny, xvel = this->pdata->xvel, yvel = this->pdata->yvel,
+       volume = this->pdata->volume, density = this->pdata->density, energy = this->pdata->energy,
+       pressure = this->pdata->pressure](const long offs) {
+        const std::array<long, 2> idx(recover_idx<long, 2>(offs, limits));
+        const int j = idx[0];
+        const int k = idx[1];
+
+        double vsqrd = 0.0;
+        for (int kv = k; kv <= k + 1; ++kv) {
+          for (int jv = j; jv <= j + 1; ++jv) {
+            vsqrd += 0.25 * (xvel[jv * (ny + 1) + kv] * xvel[jv * (ny + 1) + kv] +
+                             yvel[jv * (ny + 1) + kv] * yvel[jv * (ny + 1) + kv]);
+          }
+        }
+        const double cell_volume = volume[j * ny + k];
+        const double cell_mass = cell_volume * density[j * ny + k];
+        summary_helper o;
+        o.vol += cell_volume;
+        o.mass += cell_mass;
+        o.ie += cell_mass * energy[j * ny + k];
+        o.ke += cell_mass * 0.5 * vsqrd;
+        o.press += cell_volume * pressure[j * ny + k];
+        return o;
+      });
+
+  return {summ.vol, summ.mass, summ.ie, summ.ke, summ.press};
+}
+#endif

--- a/src/sycl/common.hpp
+++ b/src/sycl/common.hpp
@@ -1,8 +1,13 @@
 // Copyright (c) 2021 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 #pragma once
+
 #include <sstream>
+#ifndef ONEDPL_MODEL
 #include <sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
 
 static inline std::string config_string(std::string name, sycl::queue &q) {
   std::stringstream ss("");


### PR DESCRIPTION
Based off of sycl implementation.

field_summary does not currently work; the buffer-based version is
challenging to express in the functional oneDPL/PSTL abstraction. The
USM version should work, but suffers from linker issues.

I have tried to adopt a formatting convention consistent with our other programming models; each pair of iterator terminals/logical argument groups to oneDPL functions appear on their own lines. I welcome feedback about this.