### PR TITLE
Add examples for SYCL Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ List of benchmark kernels, and their sources.
 | Reduction                  | Original benchmark                        |
 | -------------------------- | ----------------------------------------- |
 | r += a[i] * b[i]           | Dot product                               |
+| dp[i] = r[i] + r'*r * d[i] | Dot product->daxpy                        |
 | r += c[i]                  | Sum of complex numbers                    |
 | (r1,r2) += (c1[i],c2[i])   | Sum of complex numbers, stored as SoA     |
 | min(abs(c[i]))             | Minimum absolute value of complex numbers |

--- a/src/dot_rank1.hpp
+++ b/src/dot_rank1.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+
+struct dot_rank1 {
+
+  // Problem size and data arrays
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
+  const long N;
+  struct data;
+  std::unique_ptr<data> pdata;
+
+  // Constructor: set up any model initialisation (not data)
+  dot_rank1(long N);
+
+  // Deconstructor: set any model finalisation
+  ~dot_rank1();
+
+  // Allocate and initalise benchmark data
+  // r will be set to 1 * 1024 / N
+  // d will be set to 2 * 1024 / N
+  // Scaling the input data is helpful to keep the reduction in range
+  void setup();
+
+  // Run the benchmark once
+  double run();
+
+  // Finalise, clearing any benchmark data
+  void teardown();
+
+  // Return expected result
+  double expect() {
+    double r_exp = 1024.0 * 1024.0 / static_cast<double>(N);
+    double d = 2.0 * 1024.0 / static_cast<double>(N)  + r_exp * 1024.0 / static_cast<double>(N);
+    return d;
+  }
+
+  // Return theoretical minimum number of GB moved in run()
+  double gigabytes() { return 1.0E-9 * sizeof(double) * 4.0 * N; }
+};

--- a/src/dot_rank1.hpp
+++ b/src/dot_rank1.hpp
@@ -33,7 +33,7 @@ struct dot_rank1 {
   // Return expected result
   double expect() {
     double r_exp = 1024.0 * 1024.0 / static_cast<double>(N);
-    double d = 2.0 * 1024.0 / static_cast<double>(N)  + r_exp * 1024.0 / static_cast<double>(N);
+    double d = 2.0 * 1024.0 / static_cast<double>(N)  + r_exp  / static_cast<double>(N);
     return d;
   }
 

--- a/src/histogram.hpp
+++ b/src/histogram.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+
+struct histogram {
+
+  // Problem size and data arrays
+  // Data arrays use C++ PIMPL because different models store data with very
+  // different types
+  const long N;
+  struct data;
+  std::unique_ptr<data> pdata;
+
+  // Constructor: set up any model initialisation (not data)
+  histogram(long N);
+
+  // Deconstructor: set any model finalisation
+  ~histogram();
+
+  // Allocate and initalise benchmark data
+  // A will be set to 8
+  // Scaling the input data is helpful to keep the reduction in range
+  void setup();
+
+  // Run the benchmark once
+  double run();
+
+  // Finalise, clearing any benchmark data
+  void teardown();
+
+  // Return expected result
+  double expect() {
+    return N;
+  }
+
+  // Return theoretical minimum number of GB moved in run()
+  double gigabytes() { return 1.0E-9 * sizeof(int) * N; }
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
               << std::endl
               << "Valid benchmarks:" << std::endl
               << "  dot, complex_sum, complex_sum_soa, complex_min, "
-                 "field_summary, describe"
+                 "field_summary, describe, dot_rank1"
               << std::endl;
     exit(EXIT_FAILURE);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Everything's Reduced authors
+// Copyright (c) 2022 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
 #include <chrono>
@@ -24,12 +24,13 @@ const auto LINE = "------------------------------------------------------------"
 #include "describe.hpp"
 #include "dot.hpp"
 #include "field_summary.hpp"
+#include "dot_rank1.hpp"
 
 #define NITERS 100
 
 #include "util.hpp"
 
-enum class Benchmark { dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe };
+enum class Benchmark { dot, complex_sum, complex_sum_soa, complex_min, field_summary, describe, dot_rank1 };
 
 // Choose the benchmark based on the input argument given from the command line
 Benchmark select_benchmark(const std::string name) {
@@ -46,6 +47,8 @@ Benchmark select_benchmark(const std::string name) {
     return Benchmark::field_summary;
   else if (name == "describe")
     return Benchmark::describe;
+  else if (name == "dot_rank1")
+    return Benchmark::dot_rank1;
   else {
     std::cerr << "Invalid benchmark: " << name << std::endl;
     exit(EXIT_FAILURE);
@@ -480,6 +483,52 @@ int main(int argc, char *argv[]) {
     print_timing("Describe", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
                  elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
                  static_cast<double>(NITERS)*d.gigabytes());
+  }
+  else if (run == Benchmark::dot_rank1) {
+    check_for_option(argc);
+    long N = get_problem_size(argv[2]);
+
+    std::vector<double> res(NITERS);
+
+    auto construct_start = clock::now();
+    dot_rank1 ranky(N);
+    auto construct_stop = clock::now();
+
+    auto setup_start = clock::now();
+    ranky.setup();
+    auto setup_stop = clock::now();
+
+    auto run_start = clock::now();
+    for (int i = 0; i < NITERS; ++i) {
+      res[i] = ranky.run();
+    }
+    auto run_stop = clock::now();
+
+    // Check solution
+    auto check_start = clock::now();
+    for (int i = 0; i < NITERS; ++i) {
+      auto r = res[i];
+      const double eps = std::numeric_limits<double>::epsilon() * N * 1.0e6;
+      if (std::abs(r - ranky.expect()) > eps) {
+        std::cerr << "Dot_rank1: result incorrect" << std::endl
+                  << "Result: " << i << " (skipping rest)" << std::endl
+                  << "Expected: " << ranky.expect() << std::endl
+                  << "Result: " << r << std::endl
+                  << "Difference: " << std::abs(r - ranky.expect()) << std::endl
+                  << "Eps: " << eps << std::endl;
+        break;
+      }
+    }
+    auto check_stop = clock::now();
+
+    auto teardown_start = clock::now();
+    ranky.teardown();
+    auto teardown_stop = clock::now();
+
+    print_timing("Dot rank1", elapsed(construct_start, construct_stop), elapsed(setup_start, setup_stop),
+                 elapsed(run_start, run_stop), elapsed(check_start, check_stop), elapsed(teardown_start, teardown_stop),
+                 static_cast<double>(NITERS)*ranky.gigabytes());
+
   }
 
   return EXIT_SUCCESS;

--- a/src/sycl/dot.cpp
+++ b/src/sycl/dot.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Everything's Reduced authors
+// Copyright (c) 2022 Everything's Reduced authors
 // SPDX-License-Identifier: MIT
 
 #include <iostream>
@@ -8,6 +8,20 @@
 
 #include <sycl.hpp>
 
+#ifdef SYCL_USM
+struct dot::data {
+  data(long N) : q(sycl::default_selector{}),
+                 A(sycl::malloc_shared<double>(N,q)),
+                 B(sycl::malloc_shared<double>(N,q)),
+                 sum(sycl::malloc_shared<double>(1,q))
+  {}
+
+  sycl::queue q;
+  double *A;
+  double *B;
+  double *sum;
+};
+#else
 struct dot::data {
   data(long N) : A(N), B(N), sum(1), q(sycl::default_selector{}) {}
 
@@ -16,6 +30,7 @@ struct dot::data {
   sycl::buffer<double> sum;
   sycl::queue q;
 };
+#endif
 
 dot::dot(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
   std::cout << config_string("Dot", pdata->q) << std::endl;
@@ -25,14 +40,24 @@ dot::~dot() {}
 
 void dot::setup() {
   pdata->q.submit([&](sycl::handler &h) {
+#ifdef SYCL_USM
+#pragma warning("what")
+    double *sum = pdata->sum;
+#else
     sycl::accessor sum(pdata->sum, h, sycl::write_only);
+#endif
     h.single_task([=]() { sum[0] = 0.0; });
   });
   pdata->q.wait();
 
   pdata->q.submit([&, N = this->N](sycl::handler &h) {
+#ifdef SYCL_USM
+    double *A = pdata->A;
+    double *B = pdata->B;
+#else
     sycl::accessor A(pdata->A, h, sycl::write_only);
     sycl::accessor B(pdata->B, h, sycl::write_only);
+#endif
     h.parallel_for(
       N,
       [=](const int i) {
@@ -44,21 +69,41 @@ void dot::setup() {
 }
 
 void dot::teardown() {
+#ifdef SYCL_USM
+  sycl::free(pdata->A, pdata->q);
+  sycl::free(pdata->B, pdata->q);
+  sycl::free(pdata->sum, pdata->q);
+#else
   pdata.reset();
+#endif
   // NOTE: All the data has been destroyed!
 }
 
 double dot::run() {
   pdata->q.submit([&](sycl::handler &h) {
+#ifdef SYCL_USM
+    double *A = pdata->A;
+    double *B = pdata->B;
+#else
     sycl::accessor A(pdata->A, h, sycl::read_only);
     sycl::accessor B(pdata->B, h, sycl::read_only);
+#endif
     h.parallel_for(
       sycl::range<1>(N),
+#ifdef SYCL_USM
+      sycl::reduction(pdata->sum, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+#else
       sycl::reduction(pdata->sum, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+#endif
       [=](sycl::id<1> i, auto &sum) {
         sum += A[i] * B[i];
       });
   });
 
+#ifdef SYCL_USM
+  pdata->q.wait();
+  return pdata->sum[0];
+#else
   return pdata->sum.get_host_access()[0];
+#endif
 }

--- a/src/sycl/dot_rank1.cpp
+++ b/src/sycl/dot_rank1.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "../dot_rank1.hpp"
+#include "common.hpp"
+
+#include <sycl.hpp>
+
+struct dot_rank1::data {
+  data(long N) : r(N), d(N), dp(N), norm2(1), q(sycl::default_selector{}) {}
+
+  sycl::buffer<double> r;
+  sycl::buffer<double> d;
+  sycl::buffer<double> dp;
+  sycl::buffer<double> norm2;
+  sycl::queue q;
+};
+
+dot_rank1::dot_rank1(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("Dot_rank1", pdata->q) << std::endl;
+}
+
+dot_rank1::~dot_rank1() {}
+
+void dot_rank1::setup() {
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor norm2(pdata->norm2, h, sycl::write_only);
+    h.single_task([=]() { norm2[0] = 0.0; });
+  });
+  pdata->q.wait();
+
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    sycl::accessor r(pdata->r, h, sycl::write_only);
+    sycl::accessor d(pdata->d, h, sycl::write_only);
+    sycl::accessor dp(pdata->dp, h, sycl::write_only);
+    h.parallel_for(
+      N,
+      [=](const int i) {
+        r[i] = 1.0 * 1024.0 / static_cast<double>(N);
+        d[i] = 2.0 * 1024.0 / static_cast<double>(N);
+        dp[i] = 3.0 * 1024.0 / static_cast<double>(N);
+      });
+  });
+  pdata->q.wait();
+}
+
+void dot_rank1::teardown() {
+  pdata.reset();
+  // NOTE: All the data has been destroyed!
+}
+
+double dot_rank1::run() {
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor r(pdata->r, h, sycl::read_only);
+    h.parallel_for(
+      sycl::range<1>(N),
+      sycl::reduction(pdata->norm2, h, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+      [=](sycl::id<1> i, auto &norm2) {
+        norm2 += r[i] * r[i];
+      });
+  });
+  pdata->q.submit([&](sycl::handler &h) {
+    sycl::accessor r(pdata->r, h, sycl::read_only);
+    sycl::accessor d(pdata->d, h, sycl::read_only);
+    sycl::accessor dp(pdata->d, h, sycl::write_only);
+    sycl::accessor norm2(pdata->norm2, h, sycl::read_only);
+    h.parallel_for(
+      sycl::range<1>(N),
+      [=](sycl::id<1> i) {
+        dp[i] = r[i] + norm2[0] * d[i];
+      });
+  });
+
+  return pdata->dp.get_host_access()[0];
+}

--- a/src/sycl/histogram.cpp
+++ b/src/sycl/histogram.cpp
@@ -62,7 +62,7 @@ double histogram::run() {
     int *A = pdata->A;
     h.parallel_for(
       sycl::range<1>(N),
-      sycl::reduction(sycl::span<int>(pdata->histogram,16), std::plus<>()),
+      sycl::reduction(sycl::span<int>(pdata->histogram,16), std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
       [=](sycl::id<1> i, auto &histo) {
         histo[A[i]] += 1;
       });

--- a/src/sycl/histogram.cpp
+++ b/src/sycl/histogram.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 Everything's Reduced authors
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "../histogram.hpp"
+#include "common.hpp"
+
+#include <sycl.hpp>
+
+struct histogram::data {
+  data(long N) : q(sycl::default_selector{}),
+                 A(sycl::malloc_shared<int>(N,q)),
+                 histogram(sycl::malloc_shared<int>(16,q))
+  {}
+
+  sycl::queue q;
+  int *A;
+  int *histogram;
+};
+
+
+histogram::histogram(long N_) : N(N_), pdata{std::make_unique<data>(N)} {
+  std::cout << config_string("histogram", pdata->q) << std::endl;
+}
+
+histogram::~histogram() {}
+
+void histogram::setup() {
+  pdata->q.submit([&](sycl::handler &h) {
+    int *histogram = pdata->histogram;
+    h.single_task([=]() { for(int i = 0; i < 16; ++i) { histogram[i] = 0.0; }});
+  });
+  pdata->q.wait();
+
+  pdata->q.submit([&, N = this->N](sycl::handler &h) {
+    int *A = pdata->A;
+    h.parallel_for(
+      N,
+      [=](const int i) {
+        A[i] = 8;
+      });
+  });
+  pdata->q.wait();
+}
+
+void histogram::teardown() {
+#ifdef SYCL_USM
+  sycl::free(pdata->A, pdata->q);
+    sycl::free(pdata->histogram, pdata->q);
+#else
+  pdata.reset();
+#endif
+  // NOTE: All the data has been destroyed!
+}
+
+double histogram::run() {
+#if defined(__INTEL_LLVM_COMPILER)
+#warning("histogram not supported on Intel/llvm compiler")
+#else
+  pdata->q.submit([&](sycl::handler &h) {
+    int *A = pdata->A;
+    h.parallel_for(
+      sycl::range<1>(N),
+      sycl::reduction(sycl::span<int>(pdata->histogram,16), std::plus<>()),
+      [=](sycl::id<1> i, auto &histo) {
+        histo[A[i]] += 1;
+      });
+  });
+
+  pdata->q.wait();
+#endif
+  return pdata->histogram[8];
+}

--- a/src/sycl/histogram.cpp
+++ b/src/sycl/histogram.cpp
@@ -62,7 +62,7 @@ double histogram::run() {
     int *A = pdata->A;
     h.parallel_for(
       sycl::range<1>(N),
-      sycl::reduction(sycl::span<int>(pdata->histogram,16), std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+      sycl::reduction(sycl::span<int, 16>(pdata->histogram,16), std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
       [=](sycl::id<1> i, auto &histo) {
         histo[A[i]] += 1;
       });


### PR DESCRIPTION
We should consider this a draft, since I'd like your comments. It's useful to have this out here to enable discussion.

Most noteworthy is that the histogram example doesn't compile with the current intel/llvm SYCL implementation because we do not support array reductions (but see https://github.com/intel/llvm/issues/5941)